### PR TITLE
SSE-2995:Stubs required for covering the scenarios related to Expired Security Digit

### DIFF
--- a/acceptance-tests/features/register.feature
+++ b/acceptance-tests/features/register.feature
@@ -76,6 +76,11 @@ Feature: Users can sign up to the self-service experience
       Then the error message "Your security code should only include numbers" must be displayed for the security code field
       And they should see the text "We have sent an email to: registering-successfully@test.gov.uk"
 
+    Scenario: The user enters a security code that has expired
+      When they submit the security code "000000"
+      Then the error message "The code you entered is not correct or has expired - enter it again or request a new code" must be displayed for the security code field
+      And they should see the text "We have sent an email to: registering-successfully@test.gov.uk"
+
   Rule: The user does not receive their email security code and clicks 'Not received an email?' link
     Background:
       When they submit the email "registering-successfully@test.gov.uk"

--- a/acceptance-tests/features/sign-in.feature
+++ b/acceptance-tests/features/sign-in.feature
@@ -42,6 +42,27 @@ Feature: Users can sign in to the self-service experience
       And they see the toggle link "Show" on the field "password"
       Then they can not see the content in the password field
 
+  Rule: The user tries to submit SMS security code
+    Background:
+      When they submit the email "registered@test.gov.uk"
+      And they submit a valid password
+      Then they should be redirected to the "/sign-in/enter-text-code" page
+
+    Scenario Outline: User submits a security code with invalid format
+      When they submit the value of security code "<code>" that <condition>
+      Then they should be redirected to the "/sign-in/enter-text-code" page
+      And the error message "<error_message>" must be displayed for the security code field
+      And they should see the text "We sent a code to:"
+
+      Examples:
+        | condition                   | code    | error_message |
+        | is empty                    |         | Enter the 6 digit security code |
+        | has more than 6 digits      | 1234567 | Enter the security code using only 6 digits |
+        | has fewer than 6 digits     | 12345   | Enter the security code using only 6 digits |
+        | contains letters            | 12345A  | Your security code should only include numbers |
+        | contains special characters | 12345$  | Your security code should only include numbers |
+        | is incorrect or expired     | 000000  | The code you entered is not correct or has expired - enter it again or request a new code |
+
   Rule: The user tries to sign in with account which is not registered
     Scenario: The user submits email and password but account is not registered
       When they submit the email "not-registered@test.gov.uk"

--- a/acceptance-tests/support/steps/input-steps.ts
+++ b/acceptance-tests/support/steps/input-steps.ts
@@ -62,3 +62,9 @@ Then("the value of the text field {} should be {string}", async function (this: 
     );
     assert.equal(elementAttributeValue, attributeValueToCheck);
 });
+
+// eslint-disable-next-line
+When("they submit the value of {} {string} that {}", async function (fieldName, value, condition) {
+    await enterTextIntoTextInput(this.page, value, fields[fieldName as keyof typeof fields]);
+    await clickSubmitButton(this.page);
+});

--- a/express/src/controllers/register.ts
+++ b/express/src/controllers/register.ts
@@ -83,6 +83,7 @@ export const submitEmailSecurityCode: RequestHandler = async (req, res) => {
     if (!req.session.emailAddress) {
         return res.redirect("/register");
     }
+
     const s4: SelfServiceServicesService = req.app.get("backing-service");
 
     try {
@@ -131,6 +132,8 @@ export const submitEmailSecurityCode: RequestHandler = async (req, res) => {
 };
 
 export const showNewPasswordForm: RequestHandler = (req, res) => {
+    console.log("In register:showNewPasswordForm");
+
     // TODO we should probably throw here and in similar cases?
     if (req.session.cognitoSession !== undefined) {
         return res.render("register/create-password.njk");

--- a/express/src/services/cognito/StubCognitoClient.ts
+++ b/express/src/services/cognito/StubCognitoClient.ts
@@ -110,7 +110,13 @@ export default class StubCognitoClient implements CognitoInterface {
         await this.getOverriddenReturnValue("login", "email", email);
     }
 
-    async login(email: string): Promise<AdminInitiateAuthCommandOutput> {
+    async login(email: string, password: string): Promise<AdminInitiateAuthCommandOutput> {
+        /* A password of 000000 is passed to indicate an invalid security code, so we need to throw appropriate error */
+        if (password == "000000") {
+            // Manually throw NotAuthorizedException
+            throw this.getException("NotAuthorizedException");
+        }
+
         const returnValue = await this.getOverriddenReturnValue("login", "email", email);
         return Promise.resolve(returnValue ?? {$metadata: {}});
     }
@@ -208,7 +214,13 @@ export default class StubCognitoClient implements CognitoInterface {
         throw new Error("Unknown exception");
     }
 
-    async respondToMfaChallenge(username: string): Promise<AdminRespondToAuthChallengeCommandOutput> {
+    async respondToMfaChallenge(username: string, mfaCode: string): Promise<AdminRespondToAuthChallengeCommandOutput> {
+        /* An MFA Code of 000000 is passed to indicate an invalid security code, so we need to throw appropriate error */
+        if (mfaCode == "000000") {
+            // Manually throw CodeMismatchException
+            throw this.getException("CodeMismatchException");
+        }
+
         const returnValue = await this.getOverriddenReturnValue("respondToMfaChallenge", "username", username);
         return Promise.resolve(returnValue ?? {$metadata: {}});
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5049,7 +5049,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
       "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-      "dev": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -6010,7 +6009,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -7025,9 +7023,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "funding": [
         {
           "type": "individual",
@@ -7577,7 +7575,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
       "integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
-      "dev": true,
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -7885,7 +7882,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -9035,7 +9031,6 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
       "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
-      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -10637,8 +10632,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/ts-jest": {
       "version": "29.1.0",
@@ -11032,14 +11026,12 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"


### PR DESCRIPTION
Currently, we do not have tests for covering the scenarios 

When a user tries to register with an expired security digit i.e., received in an email 

When a user tries to sign in with an expired security digit i.e., received on mobile 

 

Relevant stubs to be implemented for covering these scenarios 