### PR TITLE
SSE-3061 - Remove styleSrc:'unsafe-inline' from helmet

### DIFF
--- a/express/assets/css/app.scss
+++ b/express/assets/css/app.scss
@@ -181,10 +181,6 @@ code {
 }
 
 #publicKeyContainer {
-  #publicKeyLong {
-    display: none;
-  }
-
   #togglePublicKey {
     border: none;
     background: none;
@@ -266,4 +262,8 @@ code {
   .govuk-header__container {
     border-bottom: 10px solid govuk-colour("yellow");
   }
+}
+
+.white-space-nowrap {
+  white-space: nowrap;
 }

--- a/express/assets/javascripts/cookies.js
+++ b/express/assets/javascripts/cookies.js
@@ -101,11 +101,11 @@ const cookieBanner = function () {
     }
 
     function hideElement(el) {
-        el.style.display = "none";
+        el.classList.add("govuk-!-display-none");
     }
 
     function showElement(el) {
-        el.style.display = "block";
+        el.classList.remove("govuk-!-display-none");
     }
 
     function isOnCookiesPage() {

--- a/express/assets/javascripts/toggle-public-key-view.js
+++ b/express/assets/javascripts/toggle-public-key-view.js
@@ -12,8 +12,8 @@ function showFullKey() {
         publicKeyContainer.className = "";
         toggleTextChevron.className = "govuk-accordion-nav__chevron govuk-accordion-nav__chevron--down";
         buttonText.innerHTML = "Show the full public key";
-        publicKeyShort.style.display = "block";
-        publicKeyLong.style.display = "none";
+        publicKeyShort.classList.remove("govuk-!-display-none");
+        publicKeyLong.classList.add("govuk-!-display-none");
         togglePublicKey.setAttribute("aria-expanded", "false");
         publicKeyLong.removeAttribute("aria-labelledby");
         publicKeyShort.setAttribute("aria-labelledby", "public-key");
@@ -21,8 +21,8 @@ function showFullKey() {
         publicKeyContainer.className = "open";
         toggleTextChevron.className = "govuk-accordion-nav__chevron";
         buttonText.innerHTML = "Hide the full public key";
-        publicKeyShort.style.display = "none";
-        publicKeyLong.style.display = "block";
+        publicKeyShort.classList.add("govuk-!-display-none");
+        publicKeyLong.classList.remove("govuk-!-display-none");
         togglePublicKey.setAttribute("aria-expanded", "true");
         publicKeyShort.removeAttribute("aria-labelledby");
         publicKeyLong.setAttribute("aria-labelledby", "public-key");

--- a/express/src/config/helmet.ts
+++ b/express/src/config/helmet.ts
@@ -14,7 +14,7 @@ export default function Helmet() {
                     "https://www.google-analytics.com",
                     "https://ssl.google-analytics.com"
                 ],
-                styleSrc: ["'self'", "'unsafe-inline'"],
+                styleSrc: ["'self'"],
                 imgSrc: ["'self'", "data:", "https://www.googletagmanager.com", "https://www.google-analytics.com"],
                 objectSrc: ["'none'"],
                 connectSrc: ["'self'", "https://www.google-analytics.com"],

--- a/express/src/views/404.njk
+++ b/express/src/views/404.njk
@@ -8,6 +8,6 @@
   <p class="govuk-body">If you typed the web address, check it is correct.</p>
   <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
   <p class="govuk-body">
-    If the web address is correct or you selected a link or button, use our <a class="govuk-link" href="https://www.sign-in.service.gov.uk/contact-us?adminTool" style="white-space: nowrap;">support form</a> to report the problem.
+    If the web address is correct or you selected a link or button, use our <a class="govuk-link white-space-nowrap" href="https://www.sign-in.service.gov.uk/contact-us?adminTool">support form</a> to report the problem.
   </p>
 {% endblock %}

--- a/express/src/views/clients/client-details.njk
+++ b/express/src/views/clients/client-details.njk
@@ -45,7 +45,7 @@
     <div id="publicKeyContainer" class="govuk-body">
       {% if userPublicKey %}
         <div id="publicKeyShort" aria-labelledby="public-key"><code>{{ userPublicKey.slice(0, 24) }} ...</code></div>
-        <div id="publicKeyLong"><code>{{ userPublicKey }}</code></div>
+        <div id="publicKeyLong" class="govuk-!-display-none"><code>{{ userPublicKey }}</code></div>
         <button type="button" id="togglePublicKey" class="govuk-accordion__show-all" aria-expanded="false">
             <span class="govuk-accordion__section-toggle-focus">
               <span id="toggleTextChevron" class="govuk-accordion-nav__chevron govuk-accordion-nav__chevron--down"></span>

--- a/express/src/views/components/cookie-banner.njk
+++ b/express/src/views/components/cookie-banner.njk
@@ -14,9 +14,7 @@
 
 {{ govukCookieBanner({
   ariaLabel: "Cookies on GOV.UK One Login",
-  attributes: {
-    style: "display: none"
-  },
+  classes: "govuk-!-display-none",
   messages: [
     {
       headingText: "Cookies on GOV.UK One Login",
@@ -48,7 +46,7 @@
     {
       html: acceptMessageHtml,
       role: "alert",
-      hidden: true,
+      classes: "govuk-!-display-none",
       attributes: {
         id: "cookies-accepted"
       },
@@ -62,7 +60,7 @@
     {
       html: rejectMessageHtml,
       role: "alert",
-      hidden: true,
+      classes: "govuk-!-display-none",
         attributes: {
         id: "cookies-rejected"
       },


### PR DESCRIPTION
Remove styleSrc:'unsafe-inline' from helmet configuration and update the application accordingly - not to use inline styles