### PR TITLE
SSE-3131:Amend Network Template to open traffic in AWS to ServiceNow Endpoint

### DIFF
--- a/infrastructure/config/network.template.yml
+++ b/infrastructure/config/network.template.yml
@@ -47,7 +47,8 @@ Resources:
           "*.cloudfront.net",
           "*.googleapis.com",
           "*.google.com",
-          "govuk.zendesk.com"
+          "govuk.zendesk.com",
+          "*.service-now.com"
         ] ]
         AllowRules: !Sub >
           pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; content:"cognito-idp.${AWS::Region}.amazonaws.com";
@@ -67,6 +68,9 @@ Resources:
           
           pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; content:"govuk.zendesk.com";
           endswith; msg:"Pass TLS to zendesk"; flow:established; rev:1; sid:2006;)
+          
+          pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; content:".service-now.com";
+          endswith; msg:"Pass TLS to service-now"; flow:established; rev:1; sid:2007;)
 
   AccessLogsBucket:
     # checkov:skip=CKV_AWS_18:Ensure the S3 bucket has access logging enabled


### PR DESCRIPTION
Support team is moving from Zendesk to ServiceNow for handling support tickets, this is why we need to integrate ServiceNow with “Contact us“ form on Product Pages website.