### PR TITLE
SSE-3234: Backend support for "Client authentication" section in the Client page of Admin Tool

### DIFF
--- a/backend/api/src/handlers/auth/register-client.ts
+++ b/backend/api/src/handlers/auth/register-client.ts
@@ -1,14 +1,20 @@
-import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
+import {APIGatewayProxyResult} from "aws-lambda";
 import axios from "axios";
+
+export type RegisterClientPayload = {
+    service: {
+        serviceName: string;
+        id: string;
+    };
+    contactEmail: string;
+};
 
 const public_key =
     "MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAp2mLkQGo24Kz1rut0oZlviMkGomlQCH+iT1pFvegZFXq39NPjRWyatmXp/XIUPqCq9Kk8/+tq4Sgjw+EM5tATJ06j5r+35of58ATGVPniW//IhGizrv6/ebGcGEUJ0Y/ZmlCHYPV+lbewpttQ/IYKM1nr3k/Rl6qepbVYe+MpGubluQvdhgUYel9OzxiOvUk7XI0axPquiXzoEgmNNOai8+WhYTkBqE3/OucAv+XwXdnx4XHmKzMwTv93dYMpUmvTxWcSeEJ/4/SrbiK4PyHWVKU2BozfSUejVNhahAzZeyyDwhYJmhBaZi/3eOOlqGXj9UdkOXbl3vcwBH8wD30O9/4F5ERLKxzOaMnKZ+RpnygWF0qFhf+UeFMy+O06sdgiaFnXaSCsIy/SohspkKiLjNnhvrDNmPLMQbQKQlJdcp6zUzI7Gzys7luEmOxyMpA32lDBQcjL7KNwM15s4ytfrJ46XEPZUXESce2gj6NazcPPsrTa/Q2+oLS9GWupGh7AgMBAAE=";
 
-export const registerClientHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-    // TODO remove explicit any
-    // eslint-disable-next-line
-    const payload: any = event;
-
+// Handler is invoked by step function not API Gateway
+//The event type is not APIGatewayProxyEvent but the custom JSON payload from the step function invoke
+export const registerClientHandler = async (event: RegisterClientPayload): Promise<APIGatewayProxyResult> => {
     const redirect_uris = ["http://localhost/"];
     const scopes = ["openid", "email", "phone"];
     const subject_type = "pairwise";
@@ -16,10 +22,10 @@ export const registerClientHandler = async (event: APIGatewayProxyEvent): Promis
     const sector_identifier_uri = "http://gov.uk";
 
     const clientConfig = {
-        client_name: payload.service.serviceName,
+        client_name: event.service.serviceName,
         public_key: public_key,
         redirect_uris: redirect_uris,
-        contacts: [payload.contactEmail],
+        contacts: [event.contactEmail],
         scopes: scopes,
         subject_type: subject_type,
         service_type: service_type,
@@ -33,7 +39,7 @@ export const registerClientHandler = async (event: APIGatewayProxyEvent): Promis
             "X-API-Key": process.env.AUTH_API_KEY as string
         }
     });
-    const body = {...clientConfig, ...result.data, ...payload};
+    const body = {...clientConfig, ...result.data, ...event};
 
     return {
         statusCode: 200,

--- a/backend/api/src/handlers/auth/update-client.ts
+++ b/backend/api/src/handlers/auth/update-client.ts
@@ -1,12 +1,18 @@
-import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
+import {APIGatewayProxyResult} from "aws-lambda";
 import axios from "axios";
 
-export const updateClientInRegistryHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-    // TODO remove explicit any
-    // eslint-disable-next-line
-    const payload: any = event;
-    const url = process.env.AUTH_REGISTRATION_BASE_URL + "/connect/register/" + payload.clientId;
-    const result = await axios.put(url, payload.updates, {
+export type UpdateClientPayload = {
+    clientId: string;
+    serviceId: string;
+    selfServiceClientId: string;
+    updates: Record<string, unknown>;
+};
+
+// Handler is invoked by step function not API Gateway
+//The event type is not APIGatewayProxyEvent but the custom JSON payload from the step function invokes
+export const updateClientInRegistryHandler = async (event: UpdateClientPayload): Promise<APIGatewayProxyResult> => {
+    const url = process.env.AUTH_REGISTRATION_BASE_URL + "/connect/register/" + event.clientId;
+    const result = await axios.put(url, event.updates, {
         headers: {
             "Content-Type": "application/json",
             "X-API-Key": process.env.AUTH_API_KEY as string
@@ -17,9 +23,9 @@ export const updateClientInRegistryHandler = async (event: APIGatewayProxyEvent)
         statusCode: 200,
         body: JSON.stringify({
             ...result.data,
-            updates: payload.updates,
-            serviceId: payload.serviceId,
-            selfServiceClientId: payload.selfServiceClientId
+            updates: event.updates,
+            serviceId: event.serviceId,
+            selfServiceClientId: event.selfServiceClientId
         })
     };
 };

--- a/backend/api/src/handlers/dynamodb/put-service-client.ts
+++ b/backend/api/src/handlers/dynamodb/put-service-client.ts
@@ -54,6 +54,7 @@ export const putServiceClientHandler = async (event: putServiceHandlerInvokeEven
         claims: [],
         back_channel_logout_uri: payload.back_channel_logout_uri,
         sector_identifier_uri: payload.sector_identifier_uri,
+        token_endpoint_auth_method: payload.token_endpoint_auth_method,
         default_fields: [
             "data",
             "public_key",
@@ -65,7 +66,8 @@ export const putServiceClientHandler = async (event: putServiceHandlerInvokeEven
             "identity_verification_enabled",
             "claims",
             "sector_identifier_uri",
-            "back_channel_logout_uri"
+            "back_channel_logout_uri",
+            "token_endpoint_auth_method"
         ]
     };
 

--- a/backend/api/tests/handlers/auth/register-client.test.ts
+++ b/backend/api/tests/handlers/auth/register-client.test.ts
@@ -1,19 +1,17 @@
 import sinon from "sinon";
 import axios from "axios";
-import {registerClientHandler} from "../../../src/handlers/auth/register-client";
+import {RegisterClientPayload, registerClientHandler} from "../../../src/handlers/auth/register-client";
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-const postRequest = async (data): string => {
+const postRequest = async (data: RegisterClientPayload): Promise<string> => {
     const result = await registerClientHandler(data);
     return JSON.stringify(result);
 };
 
 const EXPECTED_GOOD_RESPONSE =
-    '{"statusCode":200,"body":"{\\"client_name\\":\\"My test service\\",\\"public_key\\":\\"MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAp2mLkQGo24Kz1rut0oZlviMkGomlQCH+iT1pFvegZFXq39NPjRWyatmXp/XIUPqCq9Kk8/+tq4Sgjw+EM5tATJ06j5r+35of58ATGVPniW//IhGizrv6/ebGcGEUJ0Y/ZmlCHYPV+lbewpttQ/IYKM1nr3k/Rl6qepbVYe+MpGubluQvdhgUYel9OzxiOvUk7XI0axPquiXzoEgmNNOai8+WhYTkBqE3/OucAv+XwXdnx4XHmKzMwTv93dYMpUmvTxWcSeEJ/4/SrbiK4PyHWVKU2BozfSUejVNhahAzZeyyDwhYJmhBaZi/3eOOlqGXj9UdkOXbl3vcwBH8wD30O9/4F5ERLKxzOaMnKZ+RpnygWF0qFhf+UeFMy+O06sdgiaFnXaSCsIy/SohspkKiLjNnhvrDNmPLMQbQKQlJdcp6zUzI7Gzys7luEmOxyMpA32lDBQcjL7KNwM15s4ytfrJ46XEPZUXESce2gj6NazcPPsrTa/Q2+oLS9GWupGh7AgMBAAE=\\",\\"redirect_uris\\":[\\"http://localhost/\\"],\\"contacts\\":[\\"pacttest.account@digital.cabinet-office.gov.uk\\"],\\"scopes\\":[\\"openid\\",\\"email\\",\\"phone\\"],\\"subject_type\\":\\"pairwise\\",\\"service_type\\":\\"MANDATORY\\",\\"sector_identifier_uri\\":\\"http://gov.uk\\",\\"clientId\\":\\"123\\",\\"contactEmail\\":\\"pacttest.account@digital.cabinet-office.gov.uk\\",\\"service\\":{\\"serviceName\\":\\"My test service\\"}}"}';
+    '{"statusCode":200,"body":"{\\"client_name\\":\\"My test service\\",\\"public_key\\":\\"MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAp2mLkQGo24Kz1rut0oZlviMkGomlQCH+iT1pFvegZFXq39NPjRWyatmXp/XIUPqCq9Kk8/+tq4Sgjw+EM5tATJ06j5r+35of58ATGVPniW//IhGizrv6/ebGcGEUJ0Y/ZmlCHYPV+lbewpttQ/IYKM1nr3k/Rl6qepbVYe+MpGubluQvdhgUYel9OzxiOvUk7XI0axPquiXzoEgmNNOai8+WhYTkBqE3/OucAv+XwXdnx4XHmKzMwTv93dYMpUmvTxWcSeEJ/4/SrbiK4PyHWVKU2BozfSUejVNhahAzZeyyDwhYJmhBaZi/3eOOlqGXj9UdkOXbl3vcwBH8wD30O9/4F5ERLKxzOaMnKZ+RpnygWF0qFhf+UeFMy+O06sdgiaFnXaSCsIy/SohspkKiLjNnhvrDNmPLMQbQKQlJdcp6zUzI7Gzys7luEmOxyMpA32lDBQcjL7KNwM15s4ytfrJ46XEPZUXESce2gj6NazcPPsrTa/Q2+oLS9GWupGh7AgMBAAE=\\",\\"redirect_uris\\":[\\"http://localhost/\\"],\\"contacts\\":[\\"pacttest.account@digital.cabinet-office.gov.uk\\"],\\"scopes\\":[\\"openid\\",\\"email\\",\\"phone\\"],\\"subject_type\\":\\"pairwise\\",\\"service_type\\":\\"MANDATORY\\",\\"sector_identifier_uri\\":\\"http://gov.uk\\",\\"clientId\\":\\"123\\",\\"contactEmail\\":\\"pacttest.account@digital.cabinet-office.gov.uk\\",\\"service\\":{\\"serviceName\\":\\"My test service\\",\\"id\\":\\"service#testRandomId\\"}}"}';
 
 const EXPECTED_BAD_RESPONSE =
-    '{"statusCode":200,"body":"{\\"client_name\\":\\"My test service\\",\\"public_key\\":\\"MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAp2mLkQGo24Kz1rut0oZlviMkGomlQCH+iT1pFvegZFXq39NPjRWyatmXp/XIUPqCq9Kk8/+tq4Sgjw+EM5tATJ06j5r+35of58ATGVPniW//IhGizrv6/ebGcGEUJ0Y/ZmlCHYPV+lbewpttQ/IYKM1nr3k/Rl6qepbVYe+MpGubluQvdhgUYel9OzxiOvUk7XI0axPquiXzoEgmNNOai8+WhYTkBqE3/OucAv+XwXdnx4XHmKzMwTv93dYMpUmvTxWcSeEJ/4/SrbiK4PyHWVKU2BozfSUejVNhahAzZeyyDwhYJmhBaZi/3eOOlqGXj9UdkOXbl3vcwBH8wD30O9/4F5ERLKxzOaMnKZ+RpnygWF0qFhf+UeFMy+O06sdgiaFnXaSCsIy/SohspkKiLjNnhvrDNmPLMQbQKQlJdcp6zUzI7Gzys7luEmOxyMpA32lDBQcjL7KNwM15s4ytfrJ46XEPZUXESce2gj6NazcPPsrTa/Q2+oLS9GWupGh7AgMBAAE=\\",\\"redirect_uris\\":[\\"http://localhost/\\"],\\"contacts\\":[\\"pacttest.account@digital.cabinet-office.gov.uk\\"],\\"scopes\\":[\\"openid\\",\\"email\\",\\"phone\\"],\\"subject_type\\":\\"pairwise\\",\\"service_type\\":\\"MANDATORY\\",\\"sector_identifier_uri\\":\\"http://gov.uk\\",\\"contactEmail\\":\\"pacttest.account@digital.cabinet-office.gov.uk\\",\\"service\\":{\\"serviceName\\":\\"My test service\\"}}"}';
+    '{"statusCode":200,"body":"{\\"client_name\\":\\"My test service\\",\\"public_key\\":\\"MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAp2mLkQGo24Kz1rut0oZlviMkGomlQCH+iT1pFvegZFXq39NPjRWyatmXp/XIUPqCq9Kk8/+tq4Sgjw+EM5tATJ06j5r+35of58ATGVPniW//IhGizrv6/ebGcGEUJ0Y/ZmlCHYPV+lbewpttQ/IYKM1nr3k/Rl6qepbVYe+MpGubluQvdhgUYel9OzxiOvUk7XI0axPquiXzoEgmNNOai8+WhYTkBqE3/OucAv+XwXdnx4XHmKzMwTv93dYMpUmvTxWcSeEJ/4/SrbiK4PyHWVKU2BozfSUejVNhahAzZeyyDwhYJmhBaZi/3eOOlqGXj9UdkOXbl3vcwBH8wD30O9/4F5ERLKxzOaMnKZ+RpnygWF0qFhf+UeFMy+O06sdgiaFnXaSCsIy/SohspkKiLjNnhvrDNmPLMQbQKQlJdcp6zUzI7Gzys7luEmOxyMpA32lDBQcjL7KNwM15s4ytfrJ46XEPZUXESce2gj6NazcPPsrTa/Q2+oLS9GWupGh7AgMBAAE=\\",\\"redirect_uris\\":[\\"http://localhost/\\"],\\"contacts\\":[\\"pacttest.account@digital.cabinet-office.gov.uk\\"],\\"scopes\\":[\\"openid\\",\\"email\\",\\"phone\\"],\\"subject_type\\":\\"pairwise\\",\\"service_type\\":\\"MANDATORY\\",\\"sector_identifier_uri\\":\\"http://gov.uk\\",\\"contactEmail\\":\\"pacttest.account@digital.cabinet-office.gov.uk\\",\\"service\\":{\\"serviceName\\":\\"My test service\\",\\"id\\":\\"service#testRandomId\\"}}"}';
 
 describe("exercise register-client api", () => {
     let axiosPostStub: sinon.SinonStub;
@@ -22,7 +20,8 @@ describe("exercise register-client api", () => {
     const createClientRequest = {
         contactEmail: "pacttest.account@digital.cabinet-office.gov.uk",
         service: {
-            serviceName: "My test service"
+            serviceName: "My test service",
+            id: "service#testRandomId"
         }
     };
 

--- a/backend/api/tests/handlers/auth/update-client.test.ts
+++ b/backend/api/tests/handlers/auth/update-client.test.ts
@@ -1,10 +1,8 @@
 import sinon from "sinon";
 import axios from "axios";
-import {updateClientInRegistryHandler} from "../../../src/handlers/auth/update-client";
+import {UpdateClientPayload, updateClientInRegistryHandler} from "../../../src/handlers/auth/update-client";
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-const postRequest = async (data): string => {
+const postRequest = async (data: UpdateClientPayload): Promise<string> => {
     const result = await updateClientInRegistryHandler(data);
     return JSON.stringify(result);
 };

--- a/backend/api/tests/handlers/constants.ts
+++ b/backend/api/tests/handlers/constants.ts
@@ -1,0 +1,115 @@
+import {AttributeValue} from "@aws-sdk/client-dynamodb";
+
+export const TEST_USER_ID = "1ded3d65-d088-4319-9431-ea5a3323799d";
+export const TEST_USER_EMAIL = "test@test.gov.uk";
+export const TEST_USER_FIRST_NAME = "Jane";
+export const TEST_USER_LAST_NAME = "Jones";
+export const TEST_USER_FULL_NAME = "Jones";
+export const TEST_PASSWORD_LAST_UPDATED_DATE = "01/01/2024";
+export const TEST_USER_PHONE_NUMBER = "12345678910";
+export const TEST_CLIENT_ID = "rgCBoiWHehrb4r";
+export const TEST_USER_CONFIG: Record<string, AttributeValue> = {
+    userId: {S: TEST_USER_ID},
+    fullName: {S: TEST_USER_FULL_NAME},
+    firstName: {S: TEST_USER_FIRST_NAME},
+    lastName: {S: TEST_USER_LAST_NAME},
+    email: {S: TEST_USER_EMAIL},
+    mobileNumber: {S: TEST_USER_PHONE_NUMBER},
+    passwordLastUpdated: {S: TEST_PASSWORD_LAST_UPDATED_DATE}
+};
+export const TEST_COGNITO_USER_ID = "e20b814d-55b1-4e68-a28d-3a0c4818adfa";
+export const TEST_SERVICE_ID = "488c26e5-6147-4b8e-be05-031e00310fdb";
+export const TEST_DEFAULT_PUBLIC_KEY =
+    "MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAp2mLkQGo24Kz1rut0oZlviMkGomlQCH+iT1pFvegZFXq39NPjRWyatmXp/XIUPqCq9Kk8/+tq4Sgjw+EM5tATJ06j5r+35of58ATGVPniW//IhGizrv6/ebGcGEUJ0Y/ZmlCHYPV+lbewpttQ/IYKM1nr3k/Rl6qepbVYe+MpGubluQvdhgUYel9OzxiOvUk7XI0axPquiXzoEgmNNOai8+WhYTkBqE3/OucAv+XwXdnx4XHmKzMwTv93dYMpUmvTxWcSeEJ/4/SrbiK4PyHWVKU2BozfSUejVNhahAzZeyyDwhYJmhBaZi/3eOOlqGXj9UdkOXbl3vcwBH8wD30O9/4F5ERLKxzOaMnKZ+RpnygWF0qFhf+UeFMy+O06sdgiaFnXaSCsIy/SohspkKiLjNnhvrDNmPLMQbQKQlJdcp6zUzI7Gzys7luEmOxyMpA32lDBQcjL7KNwM15s4ytfrJ46XEPZUXESce2gj6NazcPPsrTa/Q2+oLS9GWupGh7AgMBAAE=";
+
+export const TEST_DATA_TABLE_ITEM = {
+    service_name: {
+        S: "My test service 3"
+    },
+    post_logout_redirect_uris: {
+        L: [
+            {
+                S: "http://localhost/home/root"
+            }
+        ]
+    },
+    subject_type: {
+        S: "pairwise"
+    },
+    contacts: {
+        L: [
+            {
+                S: TEST_USER_EMAIL
+            },
+            {
+                S: "onboarding@digital.cabinet-office.gov.uk"
+            }
+        ]
+    },
+    public_key: {
+        S: TEST_DEFAULT_PUBLIC_KEY
+    },
+    client_name: {
+        S: "integration"
+    },
+    scopes: {
+        L: [
+            {
+                S: "openid"
+            },
+            {
+                S: "email"
+            },
+            {
+                S: "phone"
+            }
+        ]
+    },
+    clientId: {
+        S: TEST_COGNITO_USER_ID
+    },
+    default_fields: {
+        L: [
+            {
+                S: "data"
+            },
+            {
+                S: "public_key"
+            },
+            {
+                S: "redirect_uris"
+            },
+            {
+                S: "scopes"
+            },
+            {
+                S: "post_logout_redirect_uris"
+            },
+            {
+                S: "subject_type"
+            },
+            {
+                S: "service_type"
+            }
+        ]
+    },
+    redirect_uris: {
+        L: [
+            {
+                S: "http://localhost/"
+            }
+        ]
+    },
+    sk: {
+        S: TEST_CLIENT_ID
+    },
+    pk: {
+        S: TEST_SERVICE_ID
+    },
+    service_type: {
+        S: "MANDATORY"
+    },
+    type: {
+        S: "integration"
+    }
+};

--- a/backend/api/tests/handlers/dynamodb/dynamo-db-service.test.ts
+++ b/backend/api/tests/handlers/dynamodb/dynamo-db-service.test.ts
@@ -1,0 +1,204 @@
+import {
+    deleteDynamoDBClientEntriesHandler,
+    deleteDynamoDBServiceEntriesHandler,
+    getDynamoDBEntriesHandler
+} from "../../../src/handlers/dynamodb/dynamo-db-service";
+import DynamoDbClient from "../../../src/dynamodb-client";
+import {constructTestApiGatewayEvent} from "../utils";
+import {TEST_DATA_TABLE_ITEM, TEST_SERVICE_ID, TEST_USER_EMAIL, TEST_USER_ID} from "../constants";
+
+describe("getDynamoDBEntriesHandler tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("calls the getListOfClients and returns the client which includes the userEmail specified in the path params", async () => {
+        const getListOfItemsSpy = jest
+            .spyOn(DynamoDbClient.prototype, "getListOfClients")
+            .mockResolvedValue({Items: [TEST_DATA_TABLE_ITEM], $metadata: {httpStatusCode: 200}});
+
+        const serviceHandlerResponse = await getDynamoDBEntriesHandler(
+            constructTestApiGatewayEvent({body: "", pathParameters: {userEmail: TEST_USER_EMAIL}})
+        );
+
+        expect(getListOfItemsSpy).toBeCalledTimes(1);
+        expect(serviceHandlerResponse).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify(TEST_DATA_TABLE_ITEM)
+        });
+    });
+
+    it("calls the dynamo client with a scan command with the expected values and throws an error when the dynamo client throws an error", async () => {
+        const error = "SomeAwsError";
+        const getListOfItemsSpy = jest.spyOn(DynamoDbClient.prototype, "getListOfClients").mockRejectedValue(new Error(error));
+        const testEvent = constructTestApiGatewayEvent({body: "", pathParameters: {userEmail: TEST_USER_EMAIL}});
+
+        await expect(getDynamoDBEntriesHandler(testEvent)).rejects.toThrowError(error);
+        expect(getListOfItemsSpy).toBeCalledTimes(1);
+    });
+
+    it("throws an error if there is no userEmail pathParameter", async () => {
+        const getListOfItemsSpy = jest
+            .spyOn(DynamoDbClient.prototype, "getListOfClients")
+            .mockResolvedValue({Items: [TEST_DATA_TABLE_ITEM], $metadata: {httpStatusCode: 200}});
+
+        await expect(getDynamoDBEntriesHandler(constructTestApiGatewayEvent())).rejects.toThrowError(
+            "Unable to check DynamoDB for Items of User Email =>" + undefined
+        );
+        expect(getListOfItemsSpy).toBeCalledTimes(1);
+    });
+
+    it("returns an empty string in the body field if there is no matching email in the list of clients", async () => {
+        const TEST_CLIENT_ENTRY_WITH_DIFFERENT_EMAIL = {
+            ...TEST_DATA_TABLE_ITEM,
+            contacts: {
+                L: [...TEST_DATA_TABLE_ITEM.contacts.L]
+            }
+        };
+        TEST_CLIENT_ENTRY_WITH_DIFFERENT_EMAIL.contacts.L = [{S: "someEmailWhichDoesNotMatchTheProvidedOne"}];
+
+        const getListOfItemsSpy = jest
+            .spyOn(DynamoDbClient.prototype, "getListOfClients")
+            .mockResolvedValue({Items: [TEST_CLIENT_ENTRY_WITH_DIFFERENT_EMAIL], $metadata: {httpStatusCode: 200}});
+
+        const serviceHandlerResponse = await getDynamoDBEntriesHandler(
+            constructTestApiGatewayEvent({body: "", pathParameters: {userEmail: TEST_USER_EMAIL}})
+        );
+
+        expect(getListOfItemsSpy).toBeCalledTimes(1);
+        expect(serviceHandlerResponse).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify("")
+        });
+    });
+});
+
+describe("deleteDynamoDBClientEntriesHandler tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("calls the dynamo client with a delete command with the expected values and returns a 200 with the expected response body", async () => {
+        const deleteEntriesSpy = jest.spyOn(DynamoDbClient.prototype, "deleteDynamoDBClientEntries").mockResolvedValue();
+
+        const serviceHandlerResponse = await deleteDynamoDBClientEntriesHandler(
+            constructTestApiGatewayEvent({
+                body: JSON.stringify({
+                    userId: TEST_USER_ID,
+                    serviceId: TEST_SERVICE_ID
+                }),
+                pathParameters: {}
+            })
+        );
+
+        expect(deleteEntriesSpy).toHaveBeenCalledWith(TEST_USER_ID, TEST_SERVICE_ID);
+        expect(serviceHandlerResponse).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify("")
+        });
+    });
+
+    it("throws an error when no userId is provided in the event body", async () => {
+        const deleteEntriesSpy = jest.spyOn(DynamoDbClient.prototype, "deleteDynamoDBClientEntries").mockResolvedValue();
+
+        await expect(
+            deleteDynamoDBClientEntriesHandler(
+                constructTestApiGatewayEvent({
+                    body: JSON.stringify({
+                        serviceId: TEST_SERVICE_ID
+                    }),
+                    pathParameters: {}
+                })
+            )
+        ).rejects.toThrowError("No details provided for DeleteDynamoDBClientEntries");
+        expect(deleteEntriesSpy).not.toHaveBeenCalled();
+    });
+
+    it("throws an error when no serviceId is provided in the event body", async () => {
+        const deleteEntriesSpy = jest.spyOn(DynamoDbClient.prototype, "deleteDynamoDBClientEntries").mockResolvedValue();
+
+        await expect(
+            deleteDynamoDBClientEntriesHandler(
+                constructTestApiGatewayEvent({
+                    body: JSON.stringify({
+                        userId: TEST_USER_ID
+                    }),
+                    pathParameters: {}
+                })
+            )
+        ).rejects.toThrowError("No details provided for DeleteDynamoDBClientEntries");
+        expect(deleteEntriesSpy).not.toHaveBeenCalled();
+    });
+
+    it("calls the dynamo client with a delete command with the expected values and throws an error when the dynamo client throws an error", async () => {
+        const error = "SomeAwsError";
+        const deleteClientEntriesSpy = jest
+            .spyOn(DynamoDbClient.prototype, "deleteDynamoDBClientEntries")
+            .mockRejectedValue(new Error(error));
+
+        await expect(
+            deleteDynamoDBClientEntriesHandler(
+                constructTestApiGatewayEvent({
+                    body: JSON.stringify({
+                        userId: TEST_USER_ID,
+                        serviceId: TEST_SERVICE_ID
+                    }),
+                    pathParameters: {}
+                })
+            )
+        ).rejects.toThrowError(error);
+
+        expect(deleteClientEntriesSpy).toHaveBeenCalledWith(TEST_USER_ID, TEST_SERVICE_ID);
+    });
+});
+
+describe("deleteDynamoDBServiceEntriesHandler tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("calls the dynamo client with a delete command with the expected values and returns a 200 with the expected response body", async () => {
+        const deleteEntriesSpy = jest.spyOn(DynamoDbClient.prototype, "deleteDynamoDBServiceEntries").mockResolvedValue();
+
+        const serviceHandlerResponse = await deleteDynamoDBServiceEntriesHandler(
+            constructTestApiGatewayEvent({
+                body: JSON.stringify({
+                    serviceId: TEST_SERVICE_ID
+                }),
+                pathParameters: {}
+            })
+        );
+
+        expect(deleteEntriesSpy).toHaveBeenCalledWith(TEST_SERVICE_ID);
+        expect(serviceHandlerResponse).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify("")
+        });
+    });
+
+    it("calls the dynamo client with a delete command with the expected values and throws an error when the dynamo client throws an error", async () => {
+        const error = "SomeAwsError";
+        const deleteEntriesSpy = jest.spyOn(DynamoDbClient.prototype, "deleteDynamoDBServiceEntries").mockRejectedValue(new Error(error));
+
+        await expect(
+            deleteDynamoDBServiceEntriesHandler(
+                constructTestApiGatewayEvent({
+                    body: JSON.stringify({
+                        serviceId: TEST_SERVICE_ID
+                    }),
+                    pathParameters: {}
+                })
+            )
+        ).rejects.toThrowError(error);
+        expect(deleteEntriesSpy).toHaveBeenCalledWith(TEST_SERVICE_ID);
+    });
+
+    it("throws an error when there is no serviceId provided", async () => {
+        const deleteEntriesSpy = jest.spyOn(DynamoDbClient.prototype, "deleteDynamoDBServiceEntries").mockResolvedValue();
+
+        await expect(deleteDynamoDBServiceEntriesHandler(constructTestApiGatewayEvent())).rejects.toThrowError(
+            "No Service ID provided for DeleteDynamoDBServiceEntries"
+        );
+        expect(deleteEntriesSpy).not.toHaveBeenCalled();
+    });
+});

--- a/backend/api/tests/handlers/dynamodb/get-service-clients.test.ts
+++ b/backend/api/tests/handlers/dynamodb/get-service-clients.test.ts
@@ -1,60 +1,54 @@
-import {getServiceClientsHandler} from "../../../src/handlers/dynamodb/get-service-clients";
 import DynamoDbClient from "../../../src/dynamodb-client";
-import {APIGatewayEventDefaultAuthorizerContext, APIGatewayProxyEvent, APIGatewayProxyEventBase} from "aws-lambda";
+import {getServiceClientsHandler} from "../../../src/handlers/dynamodb/get-service-clients";
+import {TEST_SERVICE_ID} from "../constants";
+import {constructTestApiGatewayEvent} from "../utils";
 
-const serviceId = "1ded3d65-d088-4319-9431-ea5a3323799d";
-
-function createTestEvent(overrides: Partial<APIGatewayProxyEvent>): APIGatewayProxyEvent {
-    return <APIGatewayProxyEventBase<APIGatewayEventDefaultAuthorizerContext>>{
-        body: null,
-        headers: {},
-        // etc.
-        ...overrides
-    };
-}
-
-describe("updateServiceClientHandler tests", () => {
+describe("getServiceClientsHandler tests", () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it("calls the dynamo client with a get command with the expected values and returns a 200 with the expected response body", async () => {
-        const updateItemSpy = jest.spyOn(DynamoDbClient.prototype, "getClients").mockResolvedValue({
-            $metadata: {}
-        });
+    it("returns the expected response when no userId is provided in the pathParameters", async () => {
+        const getClientsSpy = jest.spyOn(DynamoDbClient.prototype, "getClients");
+        const getServiceClientsResponse = await getServiceClientsHandler(constructTestApiGatewayEvent());
 
-        const updateServiceHandlerResponse = await getServiceClientsHandler(createTestEvent({pathParameters: {serviceId: serviceId}}));
-
-        expect(updateItemSpy).toHaveBeenCalledWith(serviceId);
-
-        expect(updateServiceHandlerResponse).toStrictEqual({
-            statusCode: 200,
-            body: '{"$metadata":{}}'
-        });
-    });
-
-    it("calls the dynamo client with a get command with the expected values and returns a 500 when the dynamo client throws an error", async () => {
-        const error = "SomeAwsError";
-        const updateItemSpy = jest.spyOn(DynamoDbClient.prototype, "getClients").mockRejectedValue(error);
-
-        const updateServiceHandlerResponse = await getServiceClientsHandler(createTestEvent({pathParameters: {serviceId: serviceId}}));
-
-        expect(updateItemSpy).toHaveBeenCalledWith(serviceId);
-
-        expect(updateServiceHandlerResponse).toStrictEqual({
-            statusCode: 500,
-            body: JSON.stringify(error)
-        });
-    });
-
-    it("calls the dynamo client with a get command without the expected values and returns a 400 when the dynamo client throws an error", async () => {
-        const error = "No userId request parameter supplied";
-
-        const updateServiceHandlerResponse = await getServiceClientsHandler(createTestEvent({}));
-
-        expect(updateServiceHandlerResponse).toStrictEqual({
+        expect(getServiceClientsResponse).toStrictEqual({
             statusCode: 400,
-            body: JSON.stringify(error)
+            body: JSON.stringify("No userId request parameter supplied")
         });
+
+        expect(getClientsSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns the clients when they are returned from dynamo", async () => {
+        const testDynamoResponse = {
+            $metadata: {},
+            Items: []
+        };
+        const getClientsSpy = jest.spyOn(DynamoDbClient.prototype, "getClients").mockResolvedValue(testDynamoResponse);
+
+        const testApiEvent = constructTestApiGatewayEvent({body: "", pathParameters: {serviceId: TEST_SERVICE_ID}});
+        const getServiceClientsResponse = await getServiceClientsHandler(testApiEvent);
+
+        expect(getServiceClientsResponse).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify(testDynamoResponse)
+        });
+
+        expect(getClientsSpy).toHaveBeenCalledWith(TEST_SERVICE_ID);
+    });
+
+    it("returns an error response when the dynamo query throws an error", async () => {
+        const dynamoErr = "someDynamoError";
+        const getClientsSpy = jest.spyOn(DynamoDbClient.prototype, "getClients").mockRejectedValue(dynamoErr);
+        const testApiEvent = constructTestApiGatewayEvent({body: "", pathParameters: {serviceId: TEST_SERVICE_ID}});
+
+        const getServiceClientsResponse = await getServiceClientsHandler(testApiEvent);
+
+        expect(getServiceClientsResponse).toStrictEqual({
+            statusCode: 500,
+            body: JSON.stringify(dynamoErr)
+        });
+        expect(getClientsSpy).toHaveBeenCalledWith(TEST_SERVICE_ID);
     });
 });

--- a/backend/api/tests/handlers/dynamodb/get-services.test.ts
+++ b/backend/api/tests/handlers/dynamodb/get-services.test.ts
@@ -1,0 +1,51 @@
+import {getServicesHandler} from "../../../src/handlers/dynamodb/get-services";
+import DynamoDbClient from "../../../src/dynamodb-client";
+import {constructTestApiGatewayEvent} from "../utils";
+import {GetItemCommandOutput} from "@aws-sdk/client-dynamodb";
+import {TEST_USER_ID} from "../constants";
+
+describe("getServicesHandler tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("calls the dynamo client with a get command with the expected values and returns a 200 with the expected response body", async () => {
+        const mockDynamoResponse: GetItemCommandOutput = {
+            $metadata: {}
+        };
+        const getServicesSpy = jest.spyOn(DynamoDbClient.prototype, "getServices").mockResolvedValue(mockDynamoResponse);
+
+        const testApiGatewayEvent = constructTestApiGatewayEvent({body: "", pathParameters: {userId: TEST_USER_ID}});
+        const serviceHandlerResponse = await getServicesHandler(testApiGatewayEvent);
+
+        expect(getServicesSpy).toHaveBeenCalledWith(TEST_USER_ID);
+
+        expect(serviceHandlerResponse).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify(mockDynamoResponse)
+        });
+    });
+
+    it("calls the dynamo client with a get command with the expected values and returns a 500 when the dynamo client throws an error", async () => {
+        const error = "SomeAwsError";
+        const getServicesSpy = jest.spyOn(DynamoDbClient.prototype, "getServices").mockRejectedValue(error);
+
+        const testApiGatewayEvent = constructTestApiGatewayEvent({body: "", pathParameters: {userId: TEST_USER_ID}});
+        const serviceHandlerResponse = await getServicesHandler(testApiGatewayEvent);
+        expect(getServicesSpy).toHaveBeenCalledWith(TEST_USER_ID);
+
+        expect(serviceHandlerResponse).toStrictEqual({
+            statusCode: 500,
+            body: JSON.stringify(error)
+        });
+    });
+
+    it("returns a 400 when there is no userId Path parameter and does not call the dynamo client", async () => {
+        const error = "No userId request parameter supplied";
+        const serviceHandlerResponse = await getServicesHandler(constructTestApiGatewayEvent());
+        expect(serviceHandlerResponse).toStrictEqual({
+            statusCode: 400,
+            body: JSON.stringify(error)
+        });
+    });
+});

--- a/backend/api/tests/handlers/dynamodb/get-session-count.test.ts
+++ b/backend/api/tests/handlers/dynamodb/get-session-count.test.ts
@@ -1,0 +1,61 @@
+import {getSessionCountHandler} from "../../../src/handlers/dynamodb/get-session-count";
+import DynamoDbClient from "../../../src/dynamodb-client";
+import {ScanCommandOutput} from "@aws-sdk/client-dynamodb";
+import {constructTestApiGatewayEvent} from "../utils";
+import {TEST_USER_EMAIL} from "../constants";
+
+describe("getSessionCountHandler tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("calls the dynamo client with a get command with the expected values and returns a 200 with the expected response body", async () => {
+        const dynamoResponse: ScanCommandOutput = {$metadata: {}, Count: 1};
+        const getSessionsSpy = jest.spyOn(DynamoDbClient.prototype, "getSessions").mockResolvedValue(dynamoResponse);
+
+        const testApiGatewayEvent = constructTestApiGatewayEvent({
+            body: "",
+            pathParameters: {
+                userEmail: TEST_USER_EMAIL
+            }
+        });
+        const serviceHandlerResponse = await getSessionCountHandler(testApiGatewayEvent);
+
+        expect(getSessionsSpy).toHaveBeenCalledWith(TEST_USER_EMAIL);
+
+        expect(serviceHandlerResponse).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify({email: TEST_USER_EMAIL, sessionCount: 1})
+        });
+    });
+
+    it("calls the dynamo client with a get command with the expected values and returns a 500 when the dynamo client throws an error", async () => {
+        const error = "SomeAwsError";
+        const getSessionsSpy = jest.spyOn(DynamoDbClient.prototype, "getSessions").mockRejectedValue(error);
+
+        const testApiGatewayEvent = constructTestApiGatewayEvent({
+            body: "",
+            pathParameters: {
+                userEmail: TEST_USER_EMAIL
+            }
+        });
+        const serviceHandlerResponse = await getSessionCountHandler(testApiGatewayEvent);
+
+        expect(getSessionsSpy).toHaveBeenCalledWith(TEST_USER_EMAIL);
+
+        expect(serviceHandlerResponse).toStrictEqual({
+            statusCode: 500,
+            body: JSON.stringify({errorMessage: error})
+        });
+    });
+
+    it("Returns a 400 and does not call the dynamo client when there is no userEmail Path Parameter", async () => {
+        const getSessionsSpy = jest.spyOn(DynamoDbClient.prototype, "getSessions").mockResolvedValue({$metadata: {}});
+        const serviceHandlerResponse = await getSessionCountHandler(constructTestApiGatewayEvent());
+        expect(serviceHandlerResponse).toStrictEqual({
+            statusCode: 400,
+            body: JSON.stringify("No userEmail request parameter supplied")
+        });
+        expect(getSessionsSpy).not.toHaveBeenCalled();
+    });
+});

--- a/backend/api/tests/handlers/dynamodb/get-user.test.ts
+++ b/backend/api/tests/handlers/dynamodb/get-user.test.ts
@@ -1,0 +1,41 @@
+import {getUserHandler} from "../../../src/handlers/dynamodb/get-user";
+import DynamoDbClient from "../../../src/dynamodb-client";
+import {constructTestApiGatewayEvent} from "../utils";
+import {TEST_COGNITO_USER_ID, TEST_USER_CONFIG} from "../constants";
+import {GetItemCommandOutput} from "@aws-sdk/client-dynamodb";
+
+describe("getUserHandler tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("calls the dynamo client with a get command with the expected values and returns a 200 with the expected response body", async () => {
+        const testGetUserResponse: GetItemCommandOutput = {$metadata: {}, Item: TEST_USER_CONFIG};
+
+        const getUserSpy = jest.spyOn(DynamoDbClient.prototype, "getUser").mockResolvedValue(testGetUserResponse);
+        const serviceHandlerResponse = await getUserHandler(
+            constructTestApiGatewayEvent({body: JSON.stringify(TEST_COGNITO_USER_ID), pathParameters: {}})
+        );
+
+        expect(getUserSpy).toHaveBeenCalledWith(TEST_COGNITO_USER_ID);
+        expect(serviceHandlerResponse).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify(testGetUserResponse)
+        });
+    });
+
+    it("calls the dynamo client with a get command with the expected values and returns a 500 when the dynamo client throws an error", async () => {
+        const error = "SomeAwsError";
+        const getUserSpy = jest.spyOn(DynamoDbClient.prototype, "getUser").mockRejectedValue(error);
+
+        const serviceHandlerResponse = await getUserHandler(
+            constructTestApiGatewayEvent({body: JSON.stringify(TEST_COGNITO_USER_ID), pathParameters: {}})
+        );
+
+        expect(getUserSpy).toHaveBeenCalledWith(TEST_COGNITO_USER_ID);
+        expect(serviceHandlerResponse).toStrictEqual({
+            statusCode: 500,
+            body: JSON.stringify(error)
+        });
+    });
+});

--- a/backend/api/tests/handlers/dynamodb/global-sign-out.test.ts
+++ b/backend/api/tests/handlers/dynamodb/global-sign-out.test.ts
@@ -1,0 +1,51 @@
+import {globalSignOutHandler} from "../../../src/handlers/dynamodb/global-sign-out";
+import DynamoDbClient from "../../../src/dynamodb-client";
+import {constructTestApiGatewayEvent} from "../utils";
+import {TEST_USER_EMAIL} from "../constants";
+
+describe("globalSignOutHandler tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("calls the dynamo client with a delete command with the expected values and returns a 200 with the expected response body", async () => {
+        const mockDeleteSessionResponse = {deletedItemCount: 3};
+        const deleteSessionSpy = jest.spyOn(DynamoDbClient.prototype, "deleteSessions").mockResolvedValue(mockDeleteSessionResponse);
+
+        const serviceHandlerResponse = await globalSignOutHandler(
+            constructTestApiGatewayEvent({body: "", pathParameters: {userEmail: TEST_USER_EMAIL}})
+        );
+
+        expect(deleteSessionSpy).toHaveBeenCalledWith(TEST_USER_EMAIL);
+        expect(serviceHandlerResponse).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify({email: TEST_USER_EMAIL, ...mockDeleteSessionResponse})
+        });
+    });
+
+    it("calls the dynamo client with a delete command with the expected values and returns a 500 when the dynamo client throws an error", async () => {
+        const error = "SomeAwsError";
+        const deleteSessionSpy = jest.spyOn(DynamoDbClient.prototype, "deleteSessions").mockRejectedValue(error);
+
+        const serviceHandlerResponse = await globalSignOutHandler(
+            constructTestApiGatewayEvent({body: "", pathParameters: {userEmail: TEST_USER_EMAIL}})
+        );
+
+        expect(deleteSessionSpy).toHaveBeenCalledWith(TEST_USER_EMAIL);
+        expect(serviceHandlerResponse).toStrictEqual({
+            statusCode: 500,
+            body: JSON.stringify({errorMessage: error})
+        });
+    });
+
+    it("calls the dynamo client with a delete command without the expected values and returns a 400 when the dynamo client throws an error", async () => {
+        const deleteSessionSpy = jest.spyOn(DynamoDbClient.prototype, "deleteSessions");
+        const serviceHandlerResponse = await globalSignOutHandler(constructTestApiGatewayEvent());
+
+        expect(deleteSessionSpy).not.toHaveBeenCalled();
+        expect(serviceHandlerResponse).toStrictEqual({
+            statusCode: 400,
+            body: JSON.stringify("No userEmail request parameter supplied")
+        });
+    });
+});

--- a/backend/api/tests/handlers/dynamodb/put-service-client.test.ts
+++ b/backend/api/tests/handlers/dynamodb/put-service-client.test.ts
@@ -48,6 +48,7 @@ const expectedDynamoRecord = {
     claims: [],
     back_channel_logout_uri: testRegistrationResponse.back_channel_logout_uri,
     sector_identifier_uri: testRegistrationResponse.sector_identifier_uri,
+    token_endpoint_auth_method: testRegistrationResponse.token_endpoint_auth_method,
     default_fields: [
         "data",
         "public_key",
@@ -59,7 +60,8 @@ const expectedDynamoRecord = {
         "identity_verification_enabled",
         "claims",
         "sector_identifier_uri",
-        "back_channel_logout_uri"
+        "back_channel_logout_uri",
+        "token_endpoint_auth_method"
     ]
 };
 

--- a/backend/api/tests/handlers/utils.ts
+++ b/backend/api/tests/handlers/utils.ts
@@ -1,0 +1,55 @@
+import {APIGatewayProxyEvent} from "aws-lambda";
+
+export const constructTestApiGatewayEvent = (params = {body: "", pathParameters: {}}): APIGatewayProxyEvent => ({
+    httpMethod: "get",
+    body: params.body,
+    headers: {},
+    isBase64Encoded: false,
+    multiValueHeaders: {},
+    multiValueQueryStringParameters: {},
+    path: "/",
+    pathParameters: params.pathParameters,
+    queryStringParameters: {},
+    requestContext: {
+        accountId: "123456789012",
+        apiId: "1234",
+        authorizer: {
+            claims: {
+                client_id: undefined
+            }
+        },
+        httpMethod: "get",
+        identity: {
+            accessKey: "",
+            accountId: "",
+            apiKey: "",
+            apiKeyId: "",
+            caller: "",
+            clientCert: {
+                clientCertPem: "",
+                issuerDN: "",
+                serialNumber: "",
+                subjectDN: "",
+                validity: {notAfter: "", notBefore: ""}
+            },
+            cognitoAuthenticationProvider: "",
+            cognitoAuthenticationType: "",
+            cognitoIdentityId: "",
+            cognitoIdentityPoolId: "",
+            principalOrgId: "",
+            sourceIp: "",
+            user: "",
+            userAgent: "",
+            userArn: ""
+        },
+        path: "/hello",
+        protocol: "HTTP/1.1",
+        requestId: "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+        requestTimeEpoch: 1428582896000,
+        resourceId: "123456",
+        resourcePath: "/hello",
+        stage: "dev"
+    },
+    resource: "",
+    stageVariables: {}
+});

--- a/express/@types/client.d.ts
+++ b/express/@types/client.d.ts
@@ -14,6 +14,8 @@ export interface ClientFromDynamo {
     subject_type: string;
     back_channel_logout_uri?: string | null;
     sector_identifier_uri: string;
+    token_endpoint_auth_method: "private_key_jwt" | "client_secret_post";
+    client_secret?: string;
     type: string;
     identity_verification_enabled: boolean;
     claims: string[];
@@ -35,6 +37,8 @@ export interface Client {
     serviceName: string;
     serviceType: string;
     subjectType: string;
+    token_endpoint_auth_method: "private_key_jwt" | "client_secret_post";
+    client_secret?: string;
     type: string;
     identity_verification_enabled: boolean;
     claims: string[];

--- a/express/src/controllers/clients.ts
+++ b/express/src/controllers/clients.ts
@@ -30,11 +30,14 @@ export const showClient: RequestHandler = async (req, res) => {
         updatedField: req.session.updatedField,
         redirectUrls: redirectUrls,
         userAttributesRequired: client.scopes,
-        userPublicKey: userPublicKey,
+        ...(client.token_endpoint_auth_method === "client_secret_post"
+            ? {client_secret: client.client_secret ?? ""}
+            : {userPublicKey: userPublicKey}),
         back_channel_logout_uri: client.back_channel_logout_uri,
         sector_identifier_uri: client.sector_identifier_uri,
         postLogoutRedirectUrls: client.postLogoutUris.join(" "),
         claims: client.identity_verification_enabled && client.hasOwnProperty("claims") ? client.claims : [],
+        token_endpoint_auth_method: client.token_endpoint_auth_method,
         urls: {
             // TODO changeClientName is currently not used
             changeClientName: `/test/services/${serviceId}/clients/${authClientId}/${selfServiceClientId}/change-client-name?clientName=${encodeURIComponent(

--- a/express/src/lib/models/client-utils.ts
+++ b/express/src/lib/models/client-utils.ts
@@ -17,6 +17,8 @@ export function dynamoClientToDomainClient(client: ClientFromDynamo): Client {
         subjectType: client.subject_type,
         type: client.type,
         sector_identifier_uri: client.sector_identifier_uri,
+        token_endpoint_auth_method: client.token_endpoint_auth_method,
+        client_secret: client.client_secret,
         back_channel_logout_uri: client.back_channel_logout_uri,
         identity_verification_enabled: client.identity_verification_enabled,
         claims: client.claims


### PR DESCRIPTION
## SSE-3234: Backend support for "Client authentication" section in the Client page of Admin Tool
### This PR Adds:
- Storing the `token_authentication_method` value in the table
- Adds custom types to `updateClientInRegistryHandler` and `registerClientHandler` as handlers are invoked by step function not API Gateway. 
- Adds `token_endpoint_auth_method` to respective types
- Adds test utility `backend/api/tests/handlers/utils.ts ` to create ApiGatewayEvents
- Adds some more dynamoDb handler unit tests from Branch `SSE-3125-api-dynamodb-unit-tests`
- Adds conditional display of PublicKey vs clientSecret depending on the `token_authentication_method`

### This PR Modifies:
- Refactors some tests to remove `ts-ignore` comments 

### This PR Removes:
- N/A

> [!NOTE]  
> Most of the code changes in this PR are contained in unit tests, happy to remove this as the diff is quite large
