### PR TITLE
DOT-627: add additional department email domains to the self service experience

### DIFF
--- a/express/resources/allowed-email-domains.txt
+++ b/express/resources/allowed-email-domains.txt
@@ -7,3 +7,5 @@ Marinemanagement.org.uk
 marinemanagement.org.uk
 hmcts.net
 digital.mod.uk
+ukri.org
+uksbs.co.uk

--- a/express/src/views/register/enter-email-address.njk
+++ b/express/src/views/register/enter-email-address.njk
@@ -6,12 +6,14 @@
   <h1 class="govuk-heading-l">Enter your government email address</h1>
   <p class="govuk-body">You can only use this service if you have an email address that ends in:</p>
   <ul class="govuk-list govuk-list--bullet">
+    <li>artscouncil.org.uk</li>
+    <li>digital.mod.uk</li>
     <li>gov.uk</li>
     <li>highwaysengland.co.uk</li>
-    <li>artscouncil.org.uk</li>
-    <li>marinemanagement.org.uk</li>
     <li>hmcts.net</li>
-    <li>digital.mod.uk</li>
+    <li>marinemanagement.org.uk</li>
+    <li>ukri.org</li>
+    <li>uksbs.co.uk</li>  
   </ul>
   <p class="govuk-body"><a class="govuk-link" href="https://www.sign-in.service.gov.uk/contact-us?adminTool">Contact us</a>
     if you have a government email address that is not covered by this list.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6695,9 +6695,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",


### PR DESCRIPTION
[DOT-627](https://govukverify.atlassian.net/browse/DOT-627)
 
# What 
Enable the UK Shared Business Services and UK Research and Innovation teams to onboard to the self service tool 

- add uksbs.co.uk and ukri.org as valid email domains to allowed-email-domains.txt
- add uksbs.co.uk and ukri.org to the enter-email-address.njk template to display list of valid domains to the user
- sort the list of domains in the enter-email0address.njk template in alphabetic sequence for ease of reading

# How to review
- spin up locally 
- ensure emails in the uksbs.co.uk and ukri.org domains are accepted
- ensure that the domains appear in the list of acceptable domains 


[DOT-627]: https://govukverify.atlassian.net/browse/DOT-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ