### PR TITLE
SSE-2968:Added Example Tests which use the new OTP Funcitonality

### DIFF
--- a/.github/workflows/run-exampleotp-tests.yml
+++ b/.github/workflows/run-exampleotp-tests.yml
@@ -1,0 +1,67 @@
+name: exampleotp tests
+
+on:
+  workflow_call:
+    inputs:
+      environment: { required: true, type: string }
+
+permissions: { }
+concurrency: exampleotp-test-${{ inputs.environment }}-${{ github.head_ref || github.ref_name }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  run-exampleotp-tests:
+    name: exampleotp
+    runs-on: ubuntu-latest
+    defaults:
+      run: { working-directory: exampleotp-tests }
+
+    steps:
+      - name: Pull repository
+        uses: actions/checkout@v3
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm install --include-workspace-root
+
+      - name: Run cucumber tests
+        id: run-tests
+        shell: bash
+        timeout-minutes: 10
+        env:
+          REPORT: ${{ runner.temp }}/exampleotp-tests.report
+          HOST: http://localhost:3000
+          STUB_API: false
+        run: |
+          shopt -s globstar
+          features=(features/**/*.feature)
+          
+          
+          cd ../express && npm install && cd .. && npm run build-express && cd exampleotp-tests
+          
+          cd .. && npm run local > /dev/null &
+          
+          while ! curl --output /dev/null --silent --head --fail $HOST; do sleep 1 && echo -n .; done;
+          
+          for feature in "${features[@]}"; do
+            [[ ${idx:-} ]] && idx=$((idx + 1)) && echo | tee heading || idx=1
+            echo "#--- [$idx/${#features[@]}] ${feature#*/} ---#" | tee -a heading && echo >> heading
+            npm run cucumber -- --format summary:results "$feature" || cat heading results >> "$REPORT"
+          done
+          
+          [[ -s $REPORT ]] && exit 1 || exit 0
+
+      - name: Report test results
+        if: ${{ failure() && steps.run-tests.outcome == 'failure' }}
+        uses: govuk-one-login/github-actions/report-step-result/print-file@5dacba941def444d69f02843feaebed79b5fca51
+        with:
+          title: exampleotp tests
+          language: shell
+          file-path: ${{ runner.temp }}/exampleotp-tests.report

--- a/express/src/lib/fixedOTPSupport.ts
+++ b/express/src/lib/fixedOTPSupport.ts
@@ -4,7 +4,6 @@ interface fixedOTPCredential {
     Email: string;
     EmailCode: string;
     SMSCode: string;
-    Telephone: string;
 }
 
 let fixedOTPCredentials: fixedOTPCredential[] = [];
@@ -36,7 +35,7 @@ function getFixedOTPCredential(emailAddress: string): number {
 export function fixedOTPInitialise(): void {
     console.log("in fixedOTPSupport - fixedOTPInitialise");
 
-    const fixedOTPCredentialsSecret = process.env.FIXED_OTP_CREDENTIALS;
+    const fixedOTPCredentialsSecret = process.env.FIXED_OTP_CREDENTIALS as string;
     fixedOTPCredentials = JSON.parse(fixedOTPCredentialsSecret as string);
 }
 
@@ -68,19 +67,6 @@ export function getFixedOTPTemporaryPassword(emailAddress: string): string {
     }
 
     return temporaryPassword;
-}
-
-export function getFixedOTPTelephone(emailAddress: string): string {
-    console.log("in fixedOTPSupport - getFixedOTPTelephone");
-
-    let telephoneNumber = "";
-    const index = getFixedOTPCredential(emailAddress);
-
-    if (index > -1) {
-        telephoneNumber = fixedOTPCredentials[index].Telephone;
-    }
-
-    return telephoneNumber;
 }
 
 export function respondToMFAChallengeForFixedOTPCredential(email: string, securityCode: string): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
         "ui-automation-tests",
         "backend/api",
         "backend/cognito",
-        "express"
+        "express",
+        "exampleotp-tests"
       ],
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.354.0",
@@ -61,6 +62,191 @@
         "@aws-sdk/client-ses": "^3.354.0",
         "esbuild": "^0.18.4",
         "notifications-node-client": "^7.0.0"
+      }
+    },
+    "exampleotp-tests": {
+      "devDependencies": {
+        "@cucumber/cucumber": "^9.1.0",
+        "puppeteer": "^20.7.2"
+      }
+    },
+    "exampleotp-tests/node_modules/@puppeteer/browsers": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.6.tgz",
+      "integrity": "sha512-x4BEjr2SjOPowNeiguzjozQbsc6h437ovD/wu+JpaenxVLm3jkgzHY2xOslMTp50HoTvQreMjiexiGQw1sqZlQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4.3.4",
+        "extract-zip": "2.0.1",
+        "progress": "2.0.3",
+        "proxy-agent": "6.3.0",
+        "tar-fs": "3.0.4",
+        "unbzip2-stream": "1.4.3",
+        "yargs": "17.7.1"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=16.3.0"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "exampleotp-tests/node_modules/chromium-bidi": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.16.tgz",
+      "integrity": "sha512-7ZbXdWERxRxSwo3txsBjjmc/NLxqb1Bk30mRb0BMS4YIaiV6zvKZqL/UAH+DdqcDYayDWk2n/y8klkBDODrPvA==",
+      "dev": true,
+      "dependencies": {
+        "mitt": "3.0.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "exampleotp-tests/node_modules/cosmiconfig": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+      "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+      "dev": true,
+      "dependencies": {
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      }
+    },
+    "exampleotp-tests/node_modules/devtools-protocol": {
+      "version": "0.0.1147663",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1147663.tgz",
+      "integrity": "sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ==",
+      "dev": true
+    },
+    "exampleotp-tests/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "exampleotp-tests/node_modules/mitt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
+      "dev": true
+    },
+    "exampleotp-tests/node_modules/proxy-agent": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.0.tgz",
+      "integrity": "sha512-0LdR757eTj/JfuU7TL2YCuAZnxWXu3tkJbg4Oq3geW/qFNT/32T0sp2HnZ9O0lMR4q3vwAt0+xCA8SR0WAD0og==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.0.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "exampleotp-tests/node_modules/puppeteer": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.9.0.tgz",
+      "integrity": "sha512-kAglT4VZ9fWEGg3oLc4/de+JcONuEJhlh3J6f5R1TLkrY/EHHIHxWXDOzXvaxQCtedmyVXBwg8M+P8YCO/wZjw==",
+      "deprecated": "< 21.8.0 is no longer supported",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@puppeteer/browsers": "1.4.6",
+        "cosmiconfig": "8.2.0",
+        "puppeteer-core": "20.9.0"
+      },
+      "engines": {
+        "node": ">=16.3.0"
+      }
+    },
+    "exampleotp-tests/node_modules/puppeteer-core": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.9.0.tgz",
+      "integrity": "sha512-H9fYZQzMTRrkboEfPmf7m3CLDN6JvbxXA3qTtS+dFt27tR+CsFHzPsT6pzp6lYL6bJbAPaR0HaPO6uSi+F94Pg==",
+      "dev": true,
+      "dependencies": {
+        "@puppeteer/browsers": "1.4.6",
+        "chromium-bidi": "0.4.16",
+        "cross-fetch": "4.0.0",
+        "debug": "4.3.4",
+        "devtools-protocol": "0.0.1147663",
+        "ws": "8.13.0"
+      },
+      "engines": {
+        "node": ">=16.3.0"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "exampleotp-tests/node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "exampleotp-tests/node_modules/yargs": {
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "express": {
@@ -6827,6 +7013,10 @@
     },
     "node_modules/gds-di-self-service-backend-cognito": {
       "resolved": "backend/cognito",
+      "link": true
+    },
+    "node_modules/gds-di-self-service-exampleotp-tests": {
+      "resolved": "exampleotp-tests",
       "link": true
     },
     "node_modules/gds-di-self-service-frontend": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "ui-automation-tests",
     "backend/api",
     "backend/cognito",
-    "express"
+    "express",
+    "exampleotp-tests"
   ],
   "scripts": {
     "build-express": "npm run build -w express",
@@ -26,7 +27,8 @@
     "lint": "eslint '*.ts' --quiet --fix",
     "acceptance": "npm run acceptance-tests -w ui-automation-tests --",
     "accessibility": "npm run accessibility-tests -w ui-automation-tests --",
-    "pii-scan": "infrastructure/dev/pii_scan.sh -p *template*.yml -i infrastructure/config/pii_scan_ignore.txt -s infrastructure/config/pii_scan_skip.txt"
+    "pii-scan": "infrastructure/dev/pii_scan.sh -p *template*.yml -i infrastructure/config/pii_scan_ignore.txt -s infrastructure/config/pii_scan_skip.txt",
+    "exampleotp": "npm run exampleotp-tests -w ui-automation-tests --"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.354.0",

--- a/ui-automation-tests/exampleotp-features/register.feature
+++ b/ui-automation-tests/exampleotp-features/register.feature
@@ -1,0 +1,20 @@
+Feature: Users can sign up to the self-service experience using real data.
+
+  Background:
+    Given the user is on the "/register" page
+
+  Rule: Register Account
+    Scenario: The user registers a new account
+      When they submit the email "testuser1@digital.cabinet-office.gov.uk"
+      Then they should be redirected to the "/register/enter-email-code" page
+      Then they submit the security code "123456"
+      Then they should be redirected to the "/register/create-password" page
+      Then they submit the password "TestUserPassword"
+      Then they should be redirected to the "/register/enter-phone-number" page
+      Then they submit the mobile phone number "07700 900000"
+      Then they should be redirected to the "/register/enter-text-code" page
+      Then they submit the security code "789012"
+      Then they should be redirected to the "/register/create-service" page
+      Then they submit the service name "Test Service 1"
+      Then pause whilst waiting to complete
+      Then they should be redirected to a page with the title "Client details - GOV.UK One Login"

--- a/ui-automation-tests/exampleotp-features/sign-in.feature
+++ b/ui-automation-tests/exampleotp-features/sign-in.feature
@@ -1,0 +1,14 @@
+Feature: Users can sign into the self-service experience using real data.
+
+  Background:
+    Given the user is on the "/sign-in" page
+
+  Rule: Register Account
+    Scenario: The user logs into an existing account
+      When they submit the email "testuser1@digital.cabinet-office.gov.uk"
+      Then they should be redirected to the "/sign-in/enter-password" page
+      Then they submit the password "TestUserPassword"
+      Then they should be redirected to the "/sign-in/enter-text-code" page
+      Then they submit the security code "789012"
+      Then pause whilst waiting to complete
+      Then they should be redirected to a page with the title "Your services - GOV.UK One Login"

--- a/ui-automation-tests/package.json
+++ b/ui-automation-tests/package.json
@@ -6,7 +6,8 @@
     "acceptance-tests-fast": "npm run cucumber -- --parallel 5",
     "acceptance-tests-report": "npm run acceptance-tests -- --format html:test-report.html",
     "accessibility-tests": "cucumber-js  accessibility-features",
-    "accessibility-report": "npm run accessibility-tests -- --format html:test-report.html"
+    "accessibility-report": "npm run accessibility-tests -- --format html:test-report.html",
+    "exampleotp-tests": "cucumber-js  exampleotp-features"
   },
   "devDependencies": {
     "@axe-core/puppeteer": "^4.8.5",

--- a/ui-automation-tests/support/steps/shared-steps.ts
+++ b/ui-automation-tests/support/steps/shared-steps.ts
@@ -161,3 +161,6 @@ Then(/^there should be no accessibility violations$/, async function (this: Test
     const results = await new AxePuppeteer(this.page).withTags(["wcag21aa", "wcag22aa"]).analyze();
     assert.equal(results.violations.length, 0, "Accessibility Violations Detected : " + JSON.stringify(results.violations));
 });
+
+// eslint-disable-next-line
+Then("pause whilst waiting to complete", {timeout: 1 * 5000}, async function () {});


### PR DESCRIPTION
This Commit contains two example Cucumber Tests which use the new OTP Functionality to create an Account and then Sign-Into it.

These tests are not designed for 'Production' Testing but can be used as Templates to produce more robust and targeted Tests or to explore  the fixedOTP Functionality.

One major caveat is the Tests are hostage to the idiosyncrasies of the Backend Cognito Interaction and therefore can fail quite often but *** THIS IS NOT *** a problem with the Tests OR the OTP Functionality but is a know issue with the application and something which can occur quite often even when using the application manually and this needs to borne in mind when running these Tests as it can be quite frustrating!!