### PR TITLE
BAU: extending backend unit test coverage

### DIFF
--- a/backend/api/package.json
+++ b/backend/api/package.json
@@ -20,6 +20,8 @@
   },
   "devDependencies": {
     "@types/sinon": "^17.0.3",
+    "aws-sdk-client-mock": "^4.0.0",
+    "aws-sdk-client-mock-jest": "^4.0.0",
     "axios-mock-adapter": "^1.22.0"
   }
 }

--- a/backend/api/tests/handlers/constants.ts
+++ b/backend/api/tests/handlers/constants.ts
@@ -115,3 +115,5 @@ export const TEST_DATA_TABLE_ITEM = {
         S: "integration"
     }
 };
+
+export const TEST_MESSAGE_ID = "1234";

--- a/backend/api/tests/handlers/constants.ts
+++ b/backend/api/tests/handlers/constants.ts
@@ -1,6 +1,7 @@
 import {AttributeValue} from "@aws-sdk/client-dynamodb";
 
 export const TEST_USER_ID = "1ded3d65-d088-4319-9431-ea5a3323799d";
+export const TEST_USER_DYNAMO_ID = "0e5033d3-91bf-4cdc-95de-7655e85b6bb4";
 export const TEST_USER_EMAIL = "test@test.gov.uk";
 export const TEST_USER_FIRST_NAME = "Jane";
 export const TEST_USER_LAST_NAME = "Jones";
@@ -8,6 +9,7 @@ export const TEST_USER_FULL_NAME = "Jones";
 export const TEST_PASSWORD_LAST_UPDATED_DATE = "01/01/2024";
 export const TEST_USER_PHONE_NUMBER = "12345678910";
 export const TEST_CLIENT_ID = "rgCBoiWHehrb4r";
+export const TEST_SERVICE_NAME = "TEST_SERVICE";
 export const TEST_USER_CONFIG: Record<string, AttributeValue> = {
     userId: {S: TEST_USER_ID},
     fullName: {S: TEST_USER_FULL_NAME},

--- a/backend/api/tests/handlers/dynamodb/put-service-user.test.ts
+++ b/backend/api/tests/handlers/dynamodb/put-service-user.test.ts
@@ -1,0 +1,53 @@
+import DynamoDbClient from "../../../src/dynamodb-client";
+import {TEST_SERVICE_ID, TEST_SERVICE_NAME, TEST_USER_DYNAMO_ID, TEST_USER_EMAIL} from "../constants";
+import {constructTestApiGatewayEvent, mockLambdaContext} from "../utils";
+import {putServiceUserHandler} from "./../../../src/handlers/dynamodb/put-service-user";
+import {PutItemCommandOutput} from "@aws-sdk/client-dynamodb";
+
+const TEST_PUT_USER_PAYLOAD = {
+    service: {
+        id: TEST_SERVICE_ID,
+        serviceName: TEST_SERVICE_NAME
+    },
+    userEmail: TEST_USER_EMAIL,
+    userDynamoId: TEST_USER_DYNAMO_ID
+};
+const TEST_PUT_USER_INVOKE_EVENT = constructTestApiGatewayEvent({body: JSON.stringify(TEST_PUT_USER_PAYLOAD), pathParameters: {}});
+
+const TEST_SERVICE_USER_RECORD = {
+    pk: TEST_SERVICE_ID,
+    sk: `user#${TEST_USER_DYNAMO_ID}`,
+    data: TEST_USER_EMAIL,
+    role: "admin",
+    service_name: TEST_SERVICE_NAME
+};
+
+describe("putServiceUser tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("returns a 200 and the stringified record in the response when the dynamo put is successful", async () => {
+        const dynamoPutItemResponse: PutItemCommandOutput = {$metadata: {httpStatusCode: 200}, Attributes: {}};
+        const dynamoPutSpy = jest.spyOn(DynamoDbClient.prototype, "put").mockResolvedValue(dynamoPutItemResponse);
+
+        const response = await putServiceUserHandler(TEST_PUT_USER_INVOKE_EVENT, mockLambdaContext);
+        expect(dynamoPutSpy).toHaveBeenCalledWith(TEST_SERVICE_USER_RECORD);
+        expect(response).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify(TEST_SERVICE_USER_RECORD)
+        });
+    });
+
+    it("returns a 500 and a stringified error when the dynamo client throws", async () => {
+        const dynamoErr = "SomeDynamoError";
+        const dynamoPutSpy = jest.spyOn(DynamoDbClient.prototype, "put").mockRejectedValue(dynamoErr);
+
+        const response = await putServiceUserHandler(TEST_PUT_USER_INVOKE_EVENT, mockLambdaContext);
+        expect(dynamoPutSpy).toHaveBeenCalledWith(TEST_SERVICE_USER_RECORD);
+        expect(response).toStrictEqual({
+            statusCode: 500,
+            body: JSON.stringify(dynamoErr)
+        });
+    });
+});

--- a/backend/api/tests/handlers/dynamodb/put-service.test.ts
+++ b/backend/api/tests/handlers/dynamodb/put-service.test.ts
@@ -1,0 +1,54 @@
+import {constructTestApiGatewayEvent, mockLambdaContext} from "../utils";
+import {putServiceHandler} from "./../../../src/handlers/dynamodb/put-service";
+import DynamoDbClient from "../../../src/dynamodb-client";
+import {PutItemCommandOutput} from "@aws-sdk/client-dynamodb";
+import {TEST_SERVICE_ID, TEST_SERVICE_NAME} from "../constants";
+
+const TEST_PUT_SERVICE_EVENT = constructTestApiGatewayEvent({
+    body: JSON.stringify({
+        service: {
+            id: TEST_SERVICE_ID,
+            serviceName: TEST_SERVICE_NAME
+        }
+    }),
+    pathParameters: {}
+});
+
+const TEST_SERVICE_RECORD = {
+    pk: TEST_SERVICE_ID,
+    sk: TEST_SERVICE_ID,
+    data: TEST_SERVICE_NAME,
+    service_name: TEST_SERVICE_NAME
+};
+
+describe("putServiceHandler tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("returns a 200 and the stringified record in the response when the dynamo put is successful", async () => {
+        const dynamoPutItemResponse: PutItemCommandOutput = {$metadata: {httpStatusCode: 200}, Attributes: {}};
+        const dynamoPutSpy = jest.spyOn(DynamoDbClient.prototype, "put").mockResolvedValue(dynamoPutItemResponse);
+
+        const response = await putServiceHandler(TEST_PUT_SERVICE_EVENT, mockLambdaContext);
+
+        expect(dynamoPutSpy).toHaveBeenCalledWith(TEST_SERVICE_RECORD);
+        expect(response).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify(dynamoPutItemResponse)
+        });
+    });
+
+    it("returns a 500 and a stringified error when the dynamo client throws an error", async () => {
+        const dynamoErr = "SomeDynamoError";
+        const dynamoPutSpy = jest.spyOn(DynamoDbClient.prototype, "put").mockRejectedValue(dynamoErr);
+
+        const response = await putServiceHandler(TEST_PUT_SERVICE_EVENT, mockLambdaContext);
+
+        expect(dynamoPutSpy).toHaveBeenCalledWith(TEST_SERVICE_RECORD);
+        expect(response).toStrictEqual({
+            statusCode: 500,
+            body: JSON.stringify(dynamoErr)
+        });
+    });
+});

--- a/backend/api/tests/handlers/dynamodb/put-user.test.ts
+++ b/backend/api/tests/handlers/dynamodb/put-user.test.ts
@@ -1,0 +1,46 @@
+import {constructTestApiGatewayEvent} from "../utils";
+import {putUserHandler} from "./../../../src/handlers/dynamodb/put-user";
+import DynamoDbClient from "../../../src/dynamodb-client";
+import {PutItemCommandOutput} from "@aws-sdk/client-dynamodb";
+import {TEST_USER_EMAIL, TEST_USER_PHONE_NUMBER} from "../constants";
+
+const TEST_USER = {
+    userEmail: TEST_USER_EMAIL,
+    phone: TEST_USER_PHONE_NUMBER
+};
+const TEST_PUT_USER_EVENT = constructTestApiGatewayEvent({
+    body: JSON.stringify(TEST_USER),
+    pathParameters: {}
+});
+
+describe("putUserHandler tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("returns a 200 and the stringified record in the response when the dynamo put is successful", async () => {
+        const dynamoPutItemResponse: PutItemCommandOutput = {$metadata: {httpStatusCode: 200}, Attributes: {}};
+        const dynamoPutSpy = jest.spyOn(DynamoDbClient.prototype, "put").mockResolvedValue(dynamoPutItemResponse);
+
+        const response = await putUserHandler(TEST_PUT_USER_EVENT);
+
+        expect(dynamoPutSpy).toHaveBeenCalledWith(TEST_USER);
+        expect(response).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify(dynamoPutItemResponse)
+        });
+    });
+
+    it("returns a 500 and a stringified error when the dynamo client throws an error", async () => {
+        const dynamoErr = "SomeDynamoError";
+        const dynamoPutSpy = jest.spyOn(DynamoDbClient.prototype, "put").mockRejectedValue(dynamoErr);
+
+        const response = await putUserHandler(TEST_PUT_USER_EVENT);
+
+        expect(dynamoPutSpy).toHaveBeenCalledWith(TEST_USER);
+        expect(response).toStrictEqual({
+            statusCode: 500,
+            body: JSON.stringify(dynamoErr)
+        });
+    });
+});

--- a/backend/api/tests/handlers/dynamodb/update-service.test.ts
+++ b/backend/api/tests/handlers/dynamodb/update-service.test.ts
@@ -1,0 +1,44 @@
+import {constructTestApiGatewayEvent} from "../utils";
+import {updateServiceHandler} from "./../../../src/handlers/dynamodb/update-service";
+import DynamoDbClient from "../../../src/dynamodb-client";
+import {TEST_SERVICE_ID, TEST_SERVICE_NAME} from "../constants";
+
+const TEST_SERVICE_UPDATES = {
+    serviceId: TEST_SERVICE_ID,
+    updates: {
+        serviceName: TEST_SERVICE_NAME
+    }
+};
+const TEST_UPDATE_SERVICE_EVENT = constructTestApiGatewayEvent({body: JSON.stringify(TEST_SERVICE_UPDATES), pathParameters: {}});
+
+describe("handlerName tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("returns a 200 and the stringified record in the response when the update is successful", async () => {
+        const serviceUpdateResponse = {message: "All records updated successfully"};
+        const updateServiceSpy = jest.spyOn(DynamoDbClient.prototype, "updateService").mockResolvedValue(serviceUpdateResponse);
+
+        const response = await updateServiceHandler(TEST_UPDATE_SERVICE_EVENT);
+
+        expect(updateServiceSpy).toHaveBeenCalledWith(TEST_SERVICE_UPDATES.serviceId, TEST_SERVICE_UPDATES.updates);
+        expect(response).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify(serviceUpdateResponse)
+        });
+    });
+
+    it("returns a 500 and a stringified error when the dynamo client throws", async () => {
+        const dynamoErr = "SomeDynamoErr";
+        const updateServiceSpy = jest.spyOn(DynamoDbClient.prototype, "updateService").mockRejectedValue(dynamoErr);
+
+        const response = await updateServiceHandler(TEST_UPDATE_SERVICE_EVENT);
+
+        expect(updateServiceSpy).toHaveBeenCalledWith(TEST_SERVICE_UPDATES.serviceId, TEST_SERVICE_UPDATES.updates);
+        expect(response).toStrictEqual({
+            statusCode: 500,
+            body: JSON.stringify(dynamoErr)
+        });
+    });
+});

--- a/backend/api/tests/handlers/dynamodb/update-user.test.ts
+++ b/backend/api/tests/handlers/dynamodb/update-user.test.ts
@@ -1,0 +1,46 @@
+import {constructTestApiGatewayEvent} from "../utils";
+import {updateUserHandler} from "./../../../src/handlers/dynamodb/update-user";
+import DynamoDbClient from "../../../src/dynamodb-client";
+import {TEST_COGNITO_USER_ID, TEST_SERVICE_NAME, TEST_USER_ID} from "../constants";
+import {UpdateItemCommandOutput} from "@aws-sdk/client-dynamodb";
+
+const TEST_USER_UPDATES = {
+    userId: TEST_USER_ID,
+    cognitoUserId: TEST_COGNITO_USER_ID,
+    updates: {
+        serviceName: TEST_SERVICE_NAME
+    }
+};
+const TEST_UPDATE_USER_EVENT = constructTestApiGatewayEvent({body: JSON.stringify(TEST_USER_UPDATES), pathParameters: {}});
+
+describe("handlerName tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("returns a 200 and the stringified record in the response when the update is successful", async () => {
+        const updateUserResponse: UpdateItemCommandOutput = {$metadata: {httpStatusCode: 200}};
+        const updateUserSpy = jest.spyOn(DynamoDbClient.prototype, "updateUser").mockResolvedValue(updateUserResponse);
+
+        const response = await updateUserHandler(TEST_UPDATE_USER_EVENT);
+
+        expect(updateUserSpy).toHaveBeenCalledWith(TEST_USER_UPDATES.userId, TEST_USER_UPDATES.cognitoUserId, TEST_USER_UPDATES.updates);
+        expect(response).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify(updateUserResponse)
+        });
+    });
+
+    it("returns a 500 and a stringified error when the dynamo client throws", async () => {
+        const dynamoErr = "SomeDynamoErr";
+        const updateUserSpy = jest.spyOn(DynamoDbClient.prototype, "updateUser").mockRejectedValue(dynamoErr);
+
+        const response = await updateUserHandler(TEST_UPDATE_USER_EVENT);
+
+        expect(updateUserSpy).toHaveBeenCalledWith(TEST_USER_UPDATES.userId, TEST_USER_UPDATES.cognitoUserId, TEST_USER_UPDATES.updates);
+        expect(response).toStrictEqual({
+            statusCode: 500,
+            body: JSON.stringify(dynamoErr)
+        });
+    });
+});

--- a/backend/api/tests/handlers/logging/sqs-service.test.ts
+++ b/backend/api/tests/handlers/logging/sqs-service.test.ts
@@ -1,0 +1,71 @@
+import {SQSClient, SendMessageCommand} from "@aws-sdk/client-sqs";
+import {TEST_MESSAGE_ID} from "../constants";
+import {constructTestApiGatewayEvent} from "../utils";
+import {sendSQSMessageToTxMAHandler} from "./../../../src/handlers/logging/sqs-service";
+import {TEST_SQS_QUEUE_URL} from "../../setup";
+import {mockClient} from "aws-sdk-client-mock";
+import "aws-sdk-client-mock-jest";
+
+const mockSqsClient = mockClient(SQSClient);
+
+const TEST_EVENT = {
+    event_name: "Hi there"
+};
+
+const TEST_HANDLER_EVENT = constructTestApiGatewayEvent({
+    body: JSON.stringify(TEST_EVENT),
+    pathParameters: {}
+});
+
+describe("sendSQSMessageToTxMAHandler tests", () => {
+    beforeEach(() => {
+        jest.spyOn(console, "log");
+        jest.clearAllMocks();
+        mockSqsClient.reset();
+    });
+
+    it("returns a 200 and the stringified success message when the sqs message sends successfully", async () => {
+        mockSqsClient.on(SendMessageCommand).resolves({MessageId: TEST_MESSAGE_ID});
+
+        const response = await sendSQSMessageToTxMAHandler(TEST_HANDLER_EVENT);
+
+        expect(mockSqsClient).toHaveReceivedCommandWith(SendMessageCommand, {
+            QueueUrl: TEST_SQS_QUEUE_URL,
+            MessageBody: JSON.stringify(TEST_EVENT)
+        });
+        expect(response).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify("Message Send to SQS - Here is MessageId: " + TEST_MESSAGE_ID)
+        });
+    });
+
+    it("returns a 200 and the phrase error stringified when there is no event body", async () => {
+        const event = constructTestApiGatewayEvent();
+        event.body = null;
+
+        const response = await sendSQSMessageToTxMAHandler(event);
+
+        expect(mockSqsClient).not.toReceiveAnyCommand();
+        expect(response).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify("Error")
+        });
+    });
+
+    it("returns a 200 and the phrase error stringified and logs the error when the sqs client throws an error", async () => {
+        const sqsErr = "sqsErr";
+        mockSqsClient.on(SendMessageCommand).rejects(sqsErr);
+
+        const response = await sendSQSMessageToTxMAHandler(TEST_HANDLER_EVENT);
+
+        expect(mockSqsClient).toHaveReceivedCommandWith(SendMessageCommand, {
+            QueueUrl: TEST_SQS_QUEUE_URL,
+            MessageBody: JSON.stringify(TEST_EVENT)
+        });
+        expect(console.log).toHaveBeenCalledWith("Error", Error(sqsErr));
+        expect(response).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify("Error")
+        });
+    });
+});

--- a/backend/api/tests/handlers/step-functions/new-client.test.ts
+++ b/backend/api/tests/handlers/step-functions/new-client.test.ts
@@ -1,0 +1,92 @@
+import {SFNClient, StartSyncExecutionCommand, SyncExecutionStatus} from "@aws-sdk/client-sfn";
+import {mockClient} from "aws-sdk-client-mock";
+import {constructTestApiGatewayEvent, mockLambdaContext} from "../utils";
+import {newClientHandler} from "../../../src/handlers/step-functions/new-client";
+import {TEST_SERVICE_ID, TEST_SERVICE_NAME, TEST_USER_EMAIL} from "../constants";
+import {TEST_STATE_MACHINE_ARN} from "../../setup";
+import "aws-sdk-client-mock-jest";
+
+const TEST_NEW_CLIENT = {
+    contactEmail: TEST_USER_EMAIL,
+    service: {
+        serviceName: TEST_SERVICE_NAME,
+        id: TEST_SERVICE_ID
+    }
+};
+const TEST_NEW_CLIENT_EVENT = constructTestApiGatewayEvent({
+    body: JSON.stringify(TEST_NEW_CLIENT),
+    pathParameters: {}
+});
+const mockSfnClient = mockClient(SFNClient);
+
+describe("newClientHandler tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("returns a 200 for a successful state machine invoke", async () => {
+        const mockSfnResponse = {
+            status: SyncExecutionStatus.SUCCEEDED,
+            $metadata: {httpStatusCode: 200},
+            executionArn: TEST_STATE_MACHINE_ARN
+        };
+        mockSfnClient.on(StartSyncExecutionCommand).resolves(mockSfnResponse);
+
+        const newClientResponse = await newClientHandler(TEST_NEW_CLIENT_EVENT, mockLambdaContext);
+
+        expect(mockSfnClient).toHaveReceivedCommandWith(StartSyncExecutionCommand, {
+            input: JSON.stringify(TEST_NEW_CLIENT),
+            stateMachineArn: TEST_STATE_MACHINE_ARN
+        });
+
+        expect(newClientResponse).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify(mockSfnResponse)
+        });
+    });
+
+    it("returns a 408 and time out result body if the function execution status is TIMED_OUT", async () => {
+        mockSfnClient.on(StartSyncExecutionCommand).resolves({
+            status: SyncExecutionStatus.TIMED_OUT,
+            $metadata: {httpStatusCode: 408},
+            executionArn: TEST_STATE_MACHINE_ARN
+        });
+
+        const newClientResponse = await newClientHandler(TEST_NEW_CLIENT_EVENT, mockLambdaContext);
+
+        expect(mockSfnClient).toHaveReceivedCommandWith(StartSyncExecutionCommand, {
+            input: JSON.stringify(TEST_NEW_CLIENT),
+            stateMachineArn: TEST_STATE_MACHINE_ARN
+        });
+
+        expect(newClientResponse).toStrictEqual({
+            statusCode: 408,
+            body: "Function timed out"
+        });
+    });
+
+    it("returns a 400 for all non timeout errors and returns the error and cause in the body", async () => {
+        const stateMachineError = "Invalid JSON";
+        const stateMachineErrorCause = "Payload";
+
+        mockSfnClient.on(StartSyncExecutionCommand).resolves({
+            status: SyncExecutionStatus.FAILED,
+            $metadata: {httpStatusCode: 400},
+            executionArn: TEST_STATE_MACHINE_ARN,
+            error: stateMachineError,
+            cause: stateMachineErrorCause
+        });
+
+        const newClientResponse = await newClientHandler(TEST_NEW_CLIENT_EVENT, mockLambdaContext);
+
+        expect(mockSfnClient).toHaveReceivedCommandWith(StartSyncExecutionCommand, {
+            input: JSON.stringify(TEST_NEW_CLIENT),
+            stateMachineArn: TEST_STATE_MACHINE_ARN
+        });
+
+        expect(newClientResponse).toStrictEqual({
+            statusCode: 400,
+            body: "Function returned error: " + stateMachineError + ", cause: " + stateMachineErrorCause
+        });
+    });
+});

--- a/backend/api/tests/handlers/step-functions/new-service.test.ts
+++ b/backend/api/tests/handlers/step-functions/new-service.test.ts
@@ -1,0 +1,91 @@
+import {SFNClient, StartSyncExecutionCommand, SyncExecutionStatus} from "@aws-sdk/client-sfn";
+import {mockClient} from "aws-sdk-client-mock";
+import {constructTestApiGatewayEvent, mockLambdaContext} from "../utils";
+import {newServiceHandler} from "../../../src/handlers/step-functions/new-service";
+import {TEST_SERVICE_ID, TEST_SERVICE_NAME} from "../constants";
+import {TEST_STATE_MACHINE_ARN} from "../../setup";
+import "aws-sdk-client-mock-jest";
+
+const TEST_NEW_SERVICE = {
+    service: {
+        serviceName: TEST_SERVICE_NAME,
+        id: TEST_SERVICE_ID
+    }
+};
+const TEST_NEW_CLIENT_EVENT = constructTestApiGatewayEvent({
+    body: JSON.stringify(TEST_NEW_SERVICE),
+    pathParameters: {}
+});
+const mockSfnClient = mockClient(SFNClient);
+
+describe("newServiceHandler tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("returns a 200 for a successful state machine invoke", async () => {
+        const mockSfnResponse = {
+            status: SyncExecutionStatus.SUCCEEDED,
+            $metadata: {httpStatusCode: 200},
+            executionArn: TEST_STATE_MACHINE_ARN
+        };
+        mockSfnClient.on(StartSyncExecutionCommand).resolves(mockSfnResponse);
+
+        const newClientResponse = await newServiceHandler(TEST_NEW_CLIENT_EVENT, mockLambdaContext);
+
+        expect(mockSfnClient).toHaveReceivedCommandWith(StartSyncExecutionCommand, {
+            input: JSON.stringify(TEST_NEW_SERVICE),
+            stateMachineArn: TEST_STATE_MACHINE_ARN
+        });
+
+        expect(newClientResponse).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify(mockSfnResponse)
+        });
+    });
+
+    it("returns a 408 and time out result body if the function execution status is TIMED_OUT", async () => {
+        mockSfnClient.on(StartSyncExecutionCommand).resolves({
+            status: SyncExecutionStatus.TIMED_OUT,
+            $metadata: {httpStatusCode: 408},
+            executionArn: TEST_STATE_MACHINE_ARN
+        });
+
+        const newClientResponse = await newServiceHandler(TEST_NEW_CLIENT_EVENT, mockLambdaContext);
+
+        expect(mockSfnClient).toHaveReceivedCommandWith(StartSyncExecutionCommand, {
+            input: JSON.stringify(TEST_NEW_SERVICE),
+            stateMachineArn: TEST_STATE_MACHINE_ARN
+        });
+
+        expect(newClientResponse).toStrictEqual({
+            statusCode: 408,
+            body: "Function timed out"
+        });
+    });
+
+    it("returns a 400 for all non timeout errors and returns the error and cause in the body", async () => {
+        const stateMachineError = "Invalid JSON";
+        const stateMachineErrorCause = "Payload";
+
+        mockSfnClient.on(StartSyncExecutionCommand).resolves({
+            status: SyncExecutionStatus.FAILED,
+            $metadata: {httpStatusCode: 400},
+            executionArn: TEST_STATE_MACHINE_ARN,
+            error: stateMachineError,
+            cause: stateMachineErrorCause
+        });
+
+        const newClientResponse = await newServiceHandler(TEST_NEW_CLIENT_EVENT, mockLambdaContext);
+
+        expect(mockSfnClient).toHaveReceivedCommandWith(StartSyncExecutionCommand, {
+            input: JSON.stringify(TEST_NEW_SERVICE),
+            stateMachineArn: TEST_STATE_MACHINE_ARN
+        });
+
+        expect(newClientResponse).toStrictEqual({
+            statusCode: 400,
+            body: "Function returned error: " + stateMachineError + ", cause: " + stateMachineErrorCause
+        });
+    });
+});

--- a/backend/api/tests/handlers/step-functions/update-client.test.ts
+++ b/backend/api/tests/handlers/step-functions/update-client.test.ts
@@ -1,0 +1,94 @@
+import {SFNClient, StartSyncExecutionCommand, SyncExecutionStatus} from "@aws-sdk/client-sfn";
+import {mockClient} from "aws-sdk-client-mock";
+import {constructTestApiGatewayEvent, mockLambdaContext} from "../utils";
+import {doUpdateClientHandler} from "../../../src/handlers/step-functions/update-client";
+import {TEST_SERVICE_ID, TEST_SERVICE_NAME, TEST_USER_EMAIL} from "../constants";
+import {TEST_STATE_MACHINE_ARN} from "../../setup";
+import "aws-sdk-client-mock-jest";
+
+const TEST_UPDATE_CLIENT = {
+    service: {
+        serviceName: TEST_SERVICE_NAME,
+        id: TEST_SERVICE_ID
+    },
+    updates: {
+        contactEmail: TEST_USER_EMAIL
+    }
+};
+const TEST_NEW_CLIENT_EVENT = constructTestApiGatewayEvent({
+    body: JSON.stringify(TEST_UPDATE_CLIENT),
+    pathParameters: {}
+});
+const mockSfnClient = mockClient(SFNClient);
+
+describe("newClientHandler tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("returns a 200 for a successful state machine invoke", async () => {
+        const mockSfnResponse = {
+            status: SyncExecutionStatus.SUCCEEDED,
+            $metadata: {httpStatusCode: 200},
+            executionArn: TEST_STATE_MACHINE_ARN
+        };
+        mockSfnClient.on(StartSyncExecutionCommand).resolves(mockSfnResponse);
+
+        const newClientResponse = await doUpdateClientHandler(TEST_NEW_CLIENT_EVENT, mockLambdaContext);
+
+        expect(mockSfnClient).toHaveReceivedCommandWith(StartSyncExecutionCommand, {
+            input: JSON.stringify(TEST_UPDATE_CLIENT),
+            stateMachineArn: TEST_STATE_MACHINE_ARN
+        });
+
+        expect(newClientResponse).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify(mockSfnResponse)
+        });
+    });
+
+    it("returns a 408 and time out result body if the function execution status is TIMED_OUT", async () => {
+        mockSfnClient.on(StartSyncExecutionCommand).resolves({
+            status: SyncExecutionStatus.TIMED_OUT,
+            $metadata: {httpStatusCode: 408},
+            executionArn: TEST_STATE_MACHINE_ARN
+        });
+
+        const newClientResponse = await doUpdateClientHandler(TEST_NEW_CLIENT_EVENT, mockLambdaContext);
+
+        expect(mockSfnClient).toHaveReceivedCommandWith(StartSyncExecutionCommand, {
+            input: JSON.stringify(TEST_UPDATE_CLIENT),
+            stateMachineArn: TEST_STATE_MACHINE_ARN
+        });
+
+        expect(newClientResponse).toStrictEqual({
+            statusCode: 408,
+            body: "Function timed out"
+        });
+    });
+
+    it("returns a 400 for all non timeout errors and returns the error and cause in the body", async () => {
+        const stateMachineError = "Invalid JSON";
+        const stateMachineErrorCause = "Payload";
+
+        mockSfnClient.on(StartSyncExecutionCommand).resolves({
+            status: SyncExecutionStatus.FAILED,
+            $metadata: {httpStatusCode: 400},
+            executionArn: TEST_STATE_MACHINE_ARN,
+            error: stateMachineError,
+            cause: stateMachineErrorCause
+        });
+
+        const newClientResponse = await doUpdateClientHandler(TEST_NEW_CLIENT_EVENT, mockLambdaContext);
+
+        expect(mockSfnClient).toHaveReceivedCommandWith(StartSyncExecutionCommand, {
+            input: JSON.stringify(TEST_UPDATE_CLIENT),
+            stateMachineArn: TEST_STATE_MACHINE_ARN
+        });
+
+        expect(newClientResponse).toStrictEqual({
+            statusCode: 400,
+            body: "Function returned error: " + stateMachineError + ", cause: " + stateMachineErrorCause
+        });
+    });
+});

--- a/backend/api/tests/handlers/utils.ts
+++ b/backend/api/tests/handlers/utils.ts
@@ -1,4 +1,5 @@
 import {APIGatewayProxyEvent} from "aws-lambda";
+import {Context} from "aws-lambda";
 
 export const constructTestApiGatewayEvent = (params = {body: "", pathParameters: {}}): APIGatewayProxyEvent => ({
     httpMethod: "get",
@@ -53,3 +54,18 @@ export const constructTestApiGatewayEvent = (params = {body: "", pathParameters:
     resource: "",
     stageVariables: {}
 });
+
+export const mockLambdaContext: Context = {
+    callbackWaitsForEmptyEventLoop: false,
+    functionName: "someFunction",
+    functionVersion: "someVersion",
+    invokedFunctionArn: "someFunctionArn",
+    memoryLimitInMB: "1",
+    awsRequestId: "someRequestId",
+    logGroupName: "someLogGroupName",
+    logStreamName: "someLogStreamName",
+    getRemainingTimeInMillis: () => 1,
+    done: jest.fn(),
+    fail: jest.fn(),
+    succeed: jest.fn()
+};

--- a/backend/api/tests/setup.ts
+++ b/backend/api/tests/setup.ts
@@ -1,2 +1,4 @@
 export const TEST_DYNAMO_TABLE_NAME = "TEST_TABLE_NAME";
+export const TEST_STATE_MACHINE_ARN = "arn:aws:eu-west-2:stateMachine:123456";
 process.env.TABLE = TEST_DYNAMO_TABLE_NAME;
+process.env.STATE_MACHINE_ARN = TEST_STATE_MACHINE_ARN;

--- a/backend/api/tests/setup.ts
+++ b/backend/api/tests/setup.ts
@@ -1,4 +1,7 @@
 export const TEST_DYNAMO_TABLE_NAME = "TEST_TABLE_NAME";
+export const TEST_SQS_QUEUE_URL = "https://sqs.eu-west-2.amazonaws.com/123456789012/QUEUE";
 export const TEST_STATE_MACHINE_ARN = "arn:aws:eu-west-2:stateMachine:123456";
+
+process.env.QUEUEURL = TEST_SQS_QUEUE_URL;
 process.env.TABLE = TEST_DYNAMO_TABLE_NAME;
 process.env.STATE_MACHINE_ARN = TEST_STATE_MACHINE_ARN;

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,8 @@
       },
       "devDependencies": {
         "@types/sinon": "^17.0.3",
+        "aws-sdk-client-mock": "^4.0.0",
+        "aws-sdk-client-mock-jest": "^4.0.0",
         "axios-mock-adapter": "^1.22.0"
       }
     },
@@ -4585,6 +4587,66 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-sdk-client-mock": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.0.0.tgz",
+      "integrity": "sha512-/rxo+pzCFaUozK7TyCqo3GYwzdBGn9Ai6EsT8ytXDoUXlD/Q5hw9hj2lOkCAyubECzGJFHMmQg9GZ1GOGlN/qQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinon": "^10.0.10",
+        "sinon": "^16.1.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/aws-sdk-client-mock-jest": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock-jest/-/aws-sdk-client-mock-jest-4.0.0.tgz",
+      "integrity": "sha512-Q8WWWYpcEZK8m0OA42Lm2LaJgStAfqvmMYVtEs2Ibz+nwjZDZSK/xlsYbdsFz93RO9cUPXbQMeyKUXeqdjh49g==",
+      "dev": true,
+      "dependencies": {
+        "expect": ">28.1.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "aws-sdk-client-mock": "4.0.0"
+      }
+    },
+    "node_modules/aws-sdk-client-mock/node_modules/@types/sinon": {
+      "version": "10.0.20",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.20.tgz",
+      "integrity": "sha512-2APKKruFNCAZgx3daAyACGzWuJ028VVCUDk6o2rw/Z4PXT0ogwdV4KUegW0MwVs0Zu59auPXbbuBJHF12Sx1Eg==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/aws-sdk-client-mock/node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/aws-sdk-client-mock/node_modules/sinon": {
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-16.1.3.tgz",
+      "integrity": "sha512-mjnWWeyxcAf9nC0bXcPmiDut+oE8HYridTNzBbF98AYVLmWwGRp2ISEpyhYflG1ifILT+eNn3BmKUJPxjXUPlA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^10.3.0",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.1.0",
+        "nise": "^5.1.4",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
       }
     },
     "node_modules/aws-sdk/node_modules/buffer": {


### PR DESCRIPTION
## BAU: Adding backend unit test coverage 
> [!NOTE]  
> This PR only adds test code and does not touch any production code

## Current Coverage:
<img width="887" alt="Screenshot 2024-03-26 at 15 50 41" src="https://github.com/govuk-one-login/onboarding-self-service-experience/assets/88101719/e2bae493-af12-4120-aaa3-3240a9d60435">

## Coverage on this branch:
<img width="900" alt="Screenshot 2024-03-26 at 15 49 15" src="https://github.com/govuk-one-login/onboarding-self-service-experience/assets/88101719/d79306fe-86b3-4356-b4d3-e3ba86937976">

### This PR Adds:
- Unit tests where they are missing for the backend lambda handlers
- Updates test utilities and setup where necessary 

### This PR Modifies:
- N/A

### This PR Removes:
- N/A


