### PR TITLE
BAU: bump express to 4.19.2

### DIFF
--- a/express/package.json
+++ b/express/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/client-sqs": "^3.398.0",
     "connect-dynamodb": "^3.0.0",
     "@govuk-one-login/one-login-analytics": "^0.0.9",
-    "express": "^4.18.2",
+    "express": "^4.19.2",
     "express-async-errors": "^3.1.1",
     "express-session": "^1.17.3",
     "govuk-frontend": "^4.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "@aws-sdk/client-sqs": "^3.398.0",
         "@govuk-one-login/one-login-analytics": "^0.0.9",
         "connect-dynamodb": "^3.0.0",
-        "express": "^4.18.2",
+        "express": "^4.19.2",
         "express-async-errors": "^3.1.1",
         "express-session": "^1.17.3",
         "govuk-frontend": "^4.8.0",
@@ -5389,9 +5389,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -6280,16 +6280,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.3.tgz",
-      "integrity": "sha512-6VyCijWQ+9O7WuVMTRBTl+cjNNIzD5cY5mQ1WM8r/LEkI2u8EYpOotESNwzNlyCn3g+dmjKYI6BmNneSr/FSRw==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
         "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -6344,14 +6344,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/express-session/node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/express-session/node_modules/cookie-signature": {


### PR DESCRIPTION
## BAU: Bump express to version 4.19.2
### This PR Adds:
 - N/A
### This PR Modifies:
- Bumps express to version 4.19.2, as older versions of express have a vulnerability when using `res.redirect()`
https://github.com/advisories/GHSA-rv95-896h-c2vc

### This PR Removes:
- N/A


