### PR TITLE
SSE-3309 - sync service name changes in Client Registry

### DIFF
--- a/backend/api/api.template.yml
+++ b/backend/api/api.template.yml
@@ -654,6 +654,38 @@ Resources:
           TABLE:
             Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
 
+  UpdateServiceFunction:
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Sourcemap: true
+        External:
+          # AWS SDK v3 dependencies are already included in the lambda runtime
+          - "@aws-sdk/*"
+    Properties:
+      Handler: backend/api/src/handlers/dynamodb/update-service.updateServiceHandler
+      CodeSigningConfigArn: !If [ UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
+      Tracing: Active
+      Policies:
+        - AWSLambdaVPCAccessExecutionRole
+        - AWSXrayWriteOnlyAccess
+        - DynamoDBWritePolicy:
+            TableName:
+              Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
+        - DynamoDBReadPolicy:
+            TableName:
+              Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
+        - !If [DynatraceLoggingEnabled, !Ref DynatraceSecretsAccessPolicy, !Ref "AWS::NoValue"]
+      Environment:
+        Variables:
+          TABLE:
+            Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
+
   UpdateServiceClientFunction:
     # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
     # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
@@ -902,20 +934,21 @@ Resources:
           # AWS SDK v3 dependencies are already included in the lambda runtime
           - "@aws-sdk/*"
     Properties:
-      Handler: backend/api/src/handlers/dynamodb/update-service.updateServiceHandler
-      Description: Updates service data in DynamoDB
+      Handler: backend/api/src/handlers/step-functions/update-service.doUpdateServiceHandler
+      Description: Updates service data in DynamoDB and Client Registry
       CodeSigningConfigArn: !If [ UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
       Tracing: Active
       Policies:
+        - AWSLambdaVPCAccessExecutionRole
         - AWSXrayWriteOnlyAccess
-        - DynamoDBCrudPolicy:
-            TableName:
-              Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
-        - !If [DynatraceLoggingEnabled, !Ref DynatraceSecretsAccessPolicy, !Ref "AWS::NoValue"]
+        - Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: states:StartSyncExecution
+              Resource: !Ref UpdateServiceStepFunction
       Environment:
         Variables:
-          TABLE:
-            Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
+          STATE_MACHINE_ARN: !Ref UpdateServiceStepFunction
       Events:
         Api:
           Type: Api
@@ -1037,6 +1070,7 @@ Resources:
                   - !GetAtt PutServiceFunction.Arn
                   - !GetAtt PutServiceUserFunction.Arn
                   - !GetAtt PutServiceClientFunction.Arn
+                  - !GetAtt UpdateServiceFunction.Arn
                   - !GetAtt UpdateServiceClientFunction.Arn
                   - !GetAtt RegisterAuthClientFunction.Arn
                   - !GetAtt UpdateAuthClientFunction.Arn
@@ -1099,6 +1133,24 @@ Resources:
       DefinitionSubstitutions:
         UpdateClientInRegistryFunctionArn: !GetAtt UpdateAuthClientFunction.Arn
         UpdateServiceClientFunctionArn: !GetAtt UpdateServiceClientFunction.Arn
+      Tracing:
+        Enabled: true
+
+  UpdateServiceStepFunction:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Type: EXPRESS
+      Role: !GetAtt StepFunctionExecutionRole.Arn
+      Logging:
+        Level: ALL
+        IncludeExecutionData: True
+        Destinations:
+          - CloudWatchLogsLogGroup:
+              LogGroupArn: !GetAtt StepFunctionsLogGroup.Arn
+      DefinitionUri: state-machines/update-service.json
+      DefinitionSubstitutions:
+        UpdateClientInRegistryFunctionArn: !GetAtt UpdateAuthClientFunction.Arn
+        UpdateServiceFunctionArn: !GetAtt UpdateServiceFunction.Arn
       Tracing:
         Enabled: true
 

--- a/backend/api/src/handlers/auth/update-client.ts
+++ b/backend/api/src/handlers/auth/update-client.ts
@@ -12,17 +12,37 @@ export type UpdateClientPayload = {
 //The event type is not APIGatewayProxyEvent but the custom JSON payload from the step function invokes
 export const updateClientInRegistryHandler = async (event: UpdateClientPayload): Promise<APIGatewayProxyResult> => {
     const url = process.env.AUTH_REGISTRATION_BASE_URL + "/connect/register/" + event.clientId;
-    const result = await axios.put(url, event.updates, {
-        headers: {
-            "Content-Type": "application/json",
-            "X-API-Key": process.env.AUTH_API_KEY as string
-        }
-    });
+    let response: never[] = [];
+    let statusCode = 200;
+
+    if (event.updates.hasOwnProperty("service_name")) {
+        // Service Name in SSE maps to Client Name in Registry
+        event.updates.client_name = event.updates.service_name;
+    }
+
+    await axios
+        .put(url, event.updates, {
+            headers: {
+                "Content-Type": "application/json",
+                "X-API-Key": process.env.AUTH_API_KEY as string
+            }
+        })
+        .then(result => {
+            response = result.data;
+            if (event.updates.hasOwnProperty("client_name")) {
+                // Must remove this if we added it otherwise later functions will break
+                delete event.updates["client_name"];
+            }
+        })
+        .catch(error => {
+            statusCode = error.response.statusCode;
+            response = error.response.data.error;
+        });
 
     return {
-        statusCode: 200,
+        statusCode: statusCode,
         body: JSON.stringify({
-            ...result.data,
+            ...response,
             updates: event.updates,
             serviceId: event.serviceId,
             selfServiceClientId: event.selfServiceClientId

--- a/backend/api/src/handlers/dynamodb/update-service-client.ts
+++ b/backend/api/src/handlers/dynamodb/update-service-client.ts
@@ -3,21 +3,22 @@ import {Updates} from "../../dynamodb-client";
 
 const client = new DynamoDbClient();
 
-export type clientRegistryUpdateResponse = {
+export type updateServiceClientPayload = {
     serviceId: string;
     selfServiceClientId: string;
     clientId: string;
     updates: Updates;
 };
 
-export type updateServiceHandlerInvokeEvent = {
+export type updateServiceClientHandlerInvokeEvent = {
     statusCode: number;
     body: string;
 };
 
-export const updateServiceClientHandler = async (event: updateServiceHandlerInvokeEvent): Promise<{statusCode: number; body: string}> => {
-    const payload: clientRegistryUpdateResponse = JSON.parse(event.body);
-
+export const updateServiceClientHandler = async (
+    event: updateServiceClientHandlerInvokeEvent
+): Promise<{statusCode: number; body: string}> => {
+    const payload: updateServiceClientPayload = JSON.parse(event.body);
     const response = {statusCode: 200, body: JSON.stringify("OK")};
 
     await client

--- a/backend/api/src/handlers/dynamodb/update-service.ts
+++ b/backend/api/src/handlers/dynamodb/update-service.ts
@@ -1,14 +1,25 @@
-import {APIGatewayProxyEvent} from "aws-lambda";
-import DynamoDbClient from "../../dynamodb-client";
+import DynamoDbClient, {Updates} from "../../dynamodb-client";
 
 const client = new DynamoDbClient();
 
-export const updateServiceHandler = async (event: APIGatewayProxyEvent): Promise<{statusCode: number; body: string}> => {
-    const body = JSON.parse(event.body as string);
+export type updateServicePayload = {
+    serviceId: string;
+    selfServiceClientId: string;
+    clientId: string;
+    updates: Updates;
+};
+
+export type updateServiceHandlerInvokeEvent = {
+    statusCode: number;
+    body: string;
+};
+
+export const updateServiceHandler = async (event: updateServiceHandlerInvokeEvent): Promise<{statusCode: number; body: string}> => {
+    const payload: updateServicePayload = JSON.parse(event.body);
     const response = {statusCode: 200, body: JSON.stringify("OK")};
 
     await client
-        .updateService(body.serviceId, body.updates)
+        .updateService(payload.serviceId, payload.updates)
         .then(updateItemCommandOutput => {
             response.statusCode = 200;
             response.body = JSON.stringify(updateItemCommandOutput);

--- a/backend/api/src/handlers/step-functions/new-client.ts
+++ b/backend/api/src/handlers/step-functions/new-client.ts
@@ -1,35 +1,7 @@
-import {SFNClient, StartSyncExecutionCommand, SyncExecutionStatus} from "@aws-sdk/client-sfn";
 import {APIGatewayProxyEvent, APIGatewayProxyResult, Context} from "aws-lambda";
-import * as process from "process";
-
-const stepFunctionsClient = new SFNClient({region: "eu-west-2"});
+import {stepFunctionHandler} from "./step-function-handler";
 
 export const newClientHandler = async (event: APIGatewayProxyEvent, context: Context): Promise<APIGatewayProxyResult> => {
-    console.info("In newClientHandler() callback from step function. Event(" + event + ") Context (" + context + ")");
-    const payload = event?.body ? JSON.parse(event.body as string) : event;
-    const stateMachineArn = process.env.STATE_MACHINE_ARN as string;
-    const input = JSON.stringify(payload);
-    const params = {
-        stateMachineArn,
-        input
-    };
-
-    const invokeCommand = new StartSyncExecutionCommand(params);
-    const result = await stepFunctionsClient.send(invokeCommand);
-
-    let statusCode = 200;
-    let resultBody: string;
-    if (result.status == SyncExecutionStatus.SUCCEEDED) {
-        resultBody = JSON.stringify(result);
-    } else if (result.status == SyncExecutionStatus.TIMED_OUT) {
-        statusCode = 408;
-        resultBody = "Function timed out";
-        console.error(resultBody);
-    } else {
-        statusCode = 400;
-        resultBody = "Function returned error: " + result.error + ", cause: " + result.cause;
-        console.error(resultBody);
-    }
-
-    return {statusCode: statusCode, body: resultBody};
+    console.info("In newClientHandler() callback from step function. Context (" + JSON.stringify(context) + ")");
+    return stepFunctionHandler(event);
 };

--- a/backend/api/src/handlers/step-functions/new-service.ts
+++ b/backend/api/src/handlers/step-functions/new-service.ts
@@ -1,35 +1,7 @@
-import {SFNClient, StartSyncExecutionCommand, SyncExecutionStatus} from "@aws-sdk/client-sfn";
 import {APIGatewayProxyEvent, APIGatewayProxyResult, Context} from "aws-lambda";
-import * as process from "process";
-
-const stepFunctionsClient = new SFNClient({region: "eu-west-2"});
+import {stepFunctionHandler} from "./step-function-handler";
 
 export const newServiceHandler = async (event: APIGatewayProxyEvent, context: Context): Promise<APIGatewayProxyResult> => {
-    console.info("In newServiceHandler() callback from step function. Event(" + event + ") Context (" + context + ")");
-    const payload = event?.body ? JSON.parse(event.body as string) : event;
-    const stateMachineArn = process.env.STATE_MACHINE_ARN as string;
-    const input = JSON.stringify(payload);
-    const params = {
-        stateMachineArn,
-        input
-    };
-
-    const invokeCommand = new StartSyncExecutionCommand(params);
-    const result = await stepFunctionsClient.send(invokeCommand);
-
-    let statusCode = 200;
-    let resultBody: string;
-    if (result.status == SyncExecutionStatus.SUCCEEDED) {
-        resultBody = JSON.stringify(result);
-    } else if (result.status == SyncExecutionStatus.TIMED_OUT) {
-        statusCode = 408;
-        resultBody = "Function timed out";
-        console.error(resultBody);
-    } else {
-        statusCode = 400;
-        resultBody = "Function returned error: " + result.error + ", cause: " + result.cause;
-        console.error(resultBody);
-    }
-
-    return {statusCode: statusCode, body: resultBody};
+    console.info("In newServiceHandler() callback from step function. Context (" + JSON.stringify(context) + ")");
+    return stepFunctionHandler(event);
 };

--- a/backend/api/src/handlers/step-functions/step-function-handler.ts
+++ b/backend/api/src/handlers/step-functions/step-function-handler.ts
@@ -1,0 +1,34 @@
+import {SFNClient, StartSyncExecutionCommand, SyncExecutionStatus} from "@aws-sdk/client-sfn";
+import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
+import * as process from "process";
+
+const stepFunctionsClient = new SFNClient({region: "eu-west-2"});
+
+export const stepFunctionHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    const payload = event?.body ? JSON.parse(event.body as string) : event;
+    const stateMachineArn = process.env.STATE_MACHINE_ARN as string;
+    const input = JSON.stringify(payload);
+    const params = {
+        stateMachineArn,
+        input
+    };
+
+    const invokeCommand = new StartSyncExecutionCommand(params);
+    const result = await stepFunctionsClient.send(invokeCommand);
+
+    let statusCode = 200;
+    let resultBody: string;
+    if (result.status == SyncExecutionStatus.SUCCEEDED) {
+        resultBody = JSON.stringify(result);
+    } else if (result.status == SyncExecutionStatus.TIMED_OUT) {
+        statusCode = 408;
+        resultBody = "Function timed out";
+        console.error(resultBody);
+    } else {
+        statusCode = 400;
+        resultBody = "Function returned error: " + result.error + ", cause: " + result.cause;
+        console.error(resultBody);
+    }
+
+    return {statusCode: statusCode, body: resultBody};
+};

--- a/backend/api/src/handlers/step-functions/update-client.ts
+++ b/backend/api/src/handlers/step-functions/update-client.ts
@@ -1,35 +1,7 @@
-import {SFNClient, StartSyncExecutionCommand, SyncExecutionStatus} from "@aws-sdk/client-sfn";
 import {APIGatewayProxyEvent, APIGatewayProxyResult, Context} from "aws-lambda";
-import * as process from "process";
-
-const stepFunctionsClient = new SFNClient({region: "eu-west-2"});
+import {stepFunctionHandler} from "./step-function-handler";
 
 export const doUpdateClientHandler = async (event: APIGatewayProxyEvent, context: Context): Promise<APIGatewayProxyResult> => {
-    console.info("In doUpdateClientHandler() callback from step function. Event(" + event + ") Context (" + context + ")");
-    const payload = event?.body ? JSON.parse(event.body as string) : event;
-    const stateMachineArn = process.env.STATE_MACHINE_ARN as string;
-    const input = JSON.stringify(payload);
-    const params = {
-        stateMachineArn,
-        input
-    };
-
-    const invokeCommand = new StartSyncExecutionCommand(params);
-    const result = await stepFunctionsClient.send(invokeCommand);
-
-    let statusCode = 200;
-    let resultBody: string;
-    if (result.status == SyncExecutionStatus.SUCCEEDED) {
-        resultBody = JSON.stringify(result);
-    } else if (result.status == SyncExecutionStatus.TIMED_OUT) {
-        statusCode = 408;
-        resultBody = "Function timed out";
-        console.error(resultBody);
-    } else {
-        statusCode = 400;
-        resultBody = "Function returned error: " + result.error + ", cause: " + result.cause;
-        console.error(resultBody);
-    }
-
-    return {statusCode: statusCode, body: resultBody};
+    console.info("In doUpdateClientHandler() callback from step function. Context (" + JSON.stringify(context) + ")");
+    return stepFunctionHandler(event);
 };

--- a/backend/api/src/handlers/step-functions/update-service.ts
+++ b/backend/api/src/handlers/step-functions/update-service.ts
@@ -1,0 +1,7 @@
+import {APIGatewayProxyEvent, APIGatewayProxyResult, Context} from "aws-lambda";
+import {stepFunctionHandler} from "./step-function-handler";
+
+export const doUpdateServiceHandler = async (event: APIGatewayProxyEvent, context: Context): Promise<APIGatewayProxyResult> => {
+    console.info("In doUpdateServiceHandler() callback from step function. Context (" + JSON.stringify(context) + ")");
+    return stepFunctionHandler(event);
+};

--- a/backend/api/state-machines/update-service.json
+++ b/backend/api/state-machines/update-service.json
@@ -1,0 +1,52 @@
+{
+  "Comment": "Update service, service user and default client data records in DynamoDB, and send relevant updates to Client Registry, by calling a number of different lambdas",
+  "StartAt": "Update client in registry",
+  "States": {
+    "Update client in registry": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$.Payload",
+      "Parameters": {
+        "FunctionName": "${UpdateClientInRegistryFunctionArn}",
+        "Payload.$": "$"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Update service",
+      "Comment": "Updates client in Auth registry"
+    },
+    "Update service": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$",
+      "Parameters": {
+        "FunctionName": "${UpdateServiceFunctionArn}",
+        "Payload.$": "$"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "End": true,
+      "Comment": "Updates service on the DDB"
+    }
+  }
+}

--- a/backend/api/tests/handlers/dynamodb/update-service.test.ts
+++ b/backend/api/tests/handlers/dynamodb/update-service.test.ts
@@ -1,15 +1,13 @@
-import {constructTestApiGatewayEvent} from "../utils";
-import {updateServiceHandler} from "./../../../src/handlers/dynamodb/update-service";
+import {updateServiceHandler} from "../../../src/handlers/dynamodb/update-service";
 import DynamoDbClient from "../../../src/dynamodb-client";
-import {TEST_SERVICE_ID, TEST_SERVICE_NAME} from "../constants";
 
-const TEST_SERVICE_UPDATES = {
-    serviceId: TEST_SERVICE_ID,
+const testRegistrationResponse = {
     updates: {
-        serviceName: TEST_SERVICE_NAME
-    }
+        service_name: "My test service 123456"
+    },
+    serviceId: "d0786cde-4e2b-4eec-a271-3a561b8cde1e",
+    clientId: "IiIznOD3UW01zmZInlOEgNYufuk"
 };
-const TEST_UPDATE_SERVICE_EVENT = constructTestApiGatewayEvent({body: JSON.stringify(TEST_SERVICE_UPDATES), pathParameters: {}});
 
 describe("handlerName tests", () => {
     beforeEach(() => {
@@ -20,9 +18,12 @@ describe("handlerName tests", () => {
         const serviceUpdateResponse = {message: "All records updated successfully"};
         const updateServiceSpy = jest.spyOn(DynamoDbClient.prototype, "updateService").mockResolvedValue(serviceUpdateResponse);
 
-        const response = await updateServiceHandler(TEST_UPDATE_SERVICE_EVENT);
+        const response = await updateServiceHandler({
+            statusCode: 200,
+            body: JSON.stringify(testRegistrationResponse)
+        });
 
-        expect(updateServiceSpy).toHaveBeenCalledWith(TEST_SERVICE_UPDATES.serviceId, TEST_SERVICE_UPDATES.updates);
+        expect(updateServiceSpy).toHaveBeenCalledWith(testRegistrationResponse.serviceId, testRegistrationResponse.updates);
         expect(response).toStrictEqual({
             statusCode: 200,
             body: JSON.stringify(serviceUpdateResponse)
@@ -33,9 +34,12 @@ describe("handlerName tests", () => {
         const dynamoErr = "SomeDynamoErr";
         const updateServiceSpy = jest.spyOn(DynamoDbClient.prototype, "updateService").mockRejectedValue(dynamoErr);
 
-        const response = await updateServiceHandler(TEST_UPDATE_SERVICE_EVENT);
+        const response = await updateServiceHandler({
+            statusCode: 200,
+            body: JSON.stringify(testRegistrationResponse)
+        });
 
-        expect(updateServiceSpy).toHaveBeenCalledWith(TEST_SERVICE_UPDATES.serviceId, TEST_SERVICE_UPDATES.updates);
+        expect(updateServiceSpy).toHaveBeenCalledWith(testRegistrationResponse.serviceId, testRegistrationResponse.updates);
         expect(response).toStrictEqual({
             statusCode: 500,
             body: JSON.stringify(dynamoErr)

--- a/backend/api/tests/handlers/step-functions/update-service.test.ts
+++ b/backend/api/tests/handlers/step-functions/update-service.test.ts
@@ -1,0 +1,94 @@
+import {SFNClient, StartSyncExecutionCommand, SyncExecutionStatus} from "@aws-sdk/client-sfn";
+import {mockClient} from "aws-sdk-client-mock";
+import {constructTestApiGatewayEvent, mockLambdaContext} from "../utils";
+import {doUpdateServiceHandler} from "../../../src/handlers/step-functions/update-service";
+import {TEST_SERVICE_ID, TEST_SERVICE_NAME, TEST_USER_EMAIL} from "../constants";
+import {TEST_STATE_MACHINE_ARN} from "../../setup";
+import "aws-sdk-client-mock-jest";
+
+const TEST_UPDATE_SERVICE = {
+    service: {
+        serviceName: TEST_SERVICE_NAME,
+        id: TEST_SERVICE_ID
+    },
+    updates: {
+        contactEmail: TEST_USER_EMAIL
+    }
+};
+const TEST_NEW_CLIENT_EVENT = constructTestApiGatewayEvent({
+    body: JSON.stringify(TEST_UPDATE_SERVICE),
+    pathParameters: {}
+});
+const mockSfnClient = mockClient(SFNClient);
+
+describe("newClientHandler tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("returns a 200 for a successful state machine invoke", async () => {
+        const mockSfnResponse = {
+            status: SyncExecutionStatus.SUCCEEDED,
+            $metadata: {httpStatusCode: 200},
+            executionArn: TEST_STATE_MACHINE_ARN
+        };
+        mockSfnClient.on(StartSyncExecutionCommand).resolves(mockSfnResponse);
+
+        const newClientResponse = await doUpdateServiceHandler(TEST_NEW_CLIENT_EVENT, mockLambdaContext);
+
+        expect(mockSfnClient).toHaveReceivedCommandWith(StartSyncExecutionCommand, {
+            input: JSON.stringify(TEST_UPDATE_SERVICE),
+            stateMachineArn: TEST_STATE_MACHINE_ARN
+        });
+
+        expect(newClientResponse).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify(mockSfnResponse)
+        });
+    });
+
+    it("returns a 408 and time out result body if the function execution status is TIMED_OUT", async () => {
+        mockSfnClient.on(StartSyncExecutionCommand).resolves({
+            status: SyncExecutionStatus.TIMED_OUT,
+            $metadata: {httpStatusCode: 408},
+            executionArn: TEST_STATE_MACHINE_ARN
+        });
+
+        const newClientResponse = await doUpdateServiceHandler(TEST_NEW_CLIENT_EVENT, mockLambdaContext);
+
+        expect(mockSfnClient).toHaveReceivedCommandWith(StartSyncExecutionCommand, {
+            input: JSON.stringify(TEST_UPDATE_SERVICE),
+            stateMachineArn: TEST_STATE_MACHINE_ARN
+        });
+
+        expect(newClientResponse).toStrictEqual({
+            statusCode: 408,
+            body: "Function timed out"
+        });
+    });
+
+    it("returns a 400 for all non timeout errors and returns the error and cause in the body", async () => {
+        const stateMachineError = "Invalid JSON";
+        const stateMachineErrorCause = "Payload";
+
+        mockSfnClient.on(StartSyncExecutionCommand).resolves({
+            status: SyncExecutionStatus.FAILED,
+            $metadata: {httpStatusCode: 400},
+            executionArn: TEST_STATE_MACHINE_ARN,
+            error: stateMachineError,
+            cause: stateMachineErrorCause
+        });
+
+        const newClientResponse = await doUpdateServiceHandler(TEST_NEW_CLIENT_EVENT, mockLambdaContext);
+
+        expect(mockSfnClient).toHaveReceivedCommandWith(StartSyncExecutionCommand, {
+            input: JSON.stringify(TEST_UPDATE_SERVICE),
+            stateMachineArn: TEST_STATE_MACHINE_ARN
+        });
+
+        expect(newClientResponse).toStrictEqual({
+            statusCode: 400,
+            body: "Function returned error: " + stateMachineError + ", cause: " + stateMachineErrorCause
+        });
+    });
+});

--- a/express/src/controllers/clients.ts
+++ b/express/src/controllers/clients.ts
@@ -206,7 +206,13 @@ export const processChangeServiceNameForm: RequestHandler = async (req, res) => 
     const s4: SelfServiceServicesService = req.app.get("backing-service");
     const userId = AuthenticationResultParser.getCognitoId(nonNull(req.session.authenticationResult));
 
-    await s4.updateService(serviceId, {service_name: newServiceName}, nonNull(req.session.authenticationResult?.AccessToken));
+    await s4.updateService(
+        serviceId,
+        req.params.selfServiceClientId,
+        req.params.clientId,
+        {service_name: newServiceName},
+        nonNull(req.session.authenticationResult?.AccessToken)
+    );
 
     req.session.updatedField = "service name";
     req.session.serviceName = newServiceName;

--- a/express/src/services/lambda-facade/LambdaFacade.ts
+++ b/express/src/services/lambda-facade/LambdaFacade.ts
@@ -69,10 +69,18 @@ export default class LambdaFacade implements LambdaFacadeInterface {
         await this.post(`/update-client`, JSON.stringify(body), accessToken);
     }
 
-    async updateService(serviceId: string, updates: ServiceNameUpdates, accessToken: string): Promise<void> {
+    async updateService(
+        serviceId: string,
+        selfServiceClientId: string,
+        clientId: string,
+        updates: ServiceNameUpdates,
+        accessToken: string
+    ): Promise<void> {
         // TODO constrain type later
         const body = {
             serviceId: serviceId,
+            selfServiceClientId: selfServiceClientId,
+            clientId: clientId,
             updates: updates
         };
 

--- a/express/src/services/lambda-facade/LambdaFacadeInterface.ts
+++ b/express/src/services/lambda-facade/LambdaFacadeInterface.ts
@@ -33,7 +33,13 @@ export default interface LambdaFacadeInterface {
         accessToken: string
     ): Promise<void>;
 
-    updateService(serviceId: string, updates: ServiceNameUpdates, accessToken: string): Promise<void>;
+    updateService(
+        serviceId: string,
+        selfServiceClientId: string,
+        clientId: string,
+        updates: ServiceNameUpdates,
+        accessToken: string
+    ): Promise<void>;
 
     sessionCount(userEmail: string): Promise<AxiosResponse>;
 

--- a/express/src/services/lambda-facade/StubLambdaFacade.ts
+++ b/express/src/services/lambda-facade/StubLambdaFacade.ts
@@ -83,7 +83,7 @@ export default class StubLambdaFacade implements LambdaFacadeInterface {
         }
     }
 
-    async updateService(serviceId: string, updates: ServiceNameUpdates): Promise<void> {
+    async updateService(serviceId: string, selfServiceClientId: string, clientId: string, updates: ServiceNameUpdates): Promise<void> {
         if (updates.service_name) {
             this.serviceName = updates.service_name as string;
         }

--- a/express/src/services/self-service-services-service.ts
+++ b/express/src/services/self-service-services-service.ts
@@ -232,10 +232,16 @@ export default class SelfServiceServicesService {
         return this.lambda.updateClient(serviceId, selfServiceClientId, clientId, updates, accessToken);
     }
 
-    async updateService(serviceId: string, updates: ServiceNameUpdates, accessToken: string): Promise<void> {
+    async updateService(
+        serviceId: string,
+        selfServiceClientId: string,
+        clientId: string,
+        updates: ServiceNameUpdates,
+        accessToken: string
+    ): Promise<void> {
         console.info("In self-service-services-service:updateService()");
         await this.validateToken(accessToken, "updateService");
-        return this.lambda.updateService(serviceId, updates, accessToken);
+        return this.lambda.updateService(serviceId, selfServiceClientId, clientId, updates, accessToken);
     }
 
     private async validateToken(accessToken: string, message: string) {


### PR DESCRIPTION
SSE-3309 - sync service name changes with client name in Client Registry when updated. Adds new step function, api configuration and unit test. Refactoring common code in the step functions. Adds extra parameter required from Frontend.