### PR TITLE
BAU: `sign-in` and `accounts` controller unit tests

### DIFF
--- a/express/src/controllers/account.ts
+++ b/express/src/controllers/account.ts
@@ -40,7 +40,7 @@ export const changePassword: RequestHandler = async (req, res) => {
         await s4.changePassword(accessToken, currentPassword, newPassword);
     } catch (error) {
         if (error instanceof CognitoIdentityProviderServiceException) {
-            const options: Record<string, Record<string, string>> = {values: {newPassword: newPassword}};
+            const options: Record<string, Record<string, string>> = {values: {newPassword: newPassword}, errorMessages: {}};
 
             if (error instanceof LimitExceededException) {
                 options.errorMessages.newPassword = "You have tried to change your password too many times. Try again in 15 minutes.";

--- a/express/src/controllers/sign-in.ts
+++ b/express/src/controllers/sign-in.ts
@@ -272,7 +272,10 @@ const forgotPassword: RequestHandler = async (req, res) => {
         }
 
         if (error instanceof CognitoIdentityProviderServiceException) {
-            const options: Record<string, Record<string, string | undefined>> = {values: {emailAddress: req.session.emailAddress}};
+            const options: Record<string, Record<string, string | undefined>> = {
+                values: {emailAddress: req.session.emailAddress},
+                errorMessages: {}
+            };
 
             if (error instanceof UserNotFoundException) {
                 console.info("User does not exist.");

--- a/express/tests/constants.ts
+++ b/express/tests/constants.ts
@@ -9,6 +9,8 @@ export const TEST_NEW_PASSWORD = "superSecurePassword456";
 export const TEST_FIRST_NAME = "firstName";
 export const TEST_LAST_NAME = "lastName";
 export const TEST_FULL_NAME = `${TEST_FIRST_NAME} ${TEST_LAST_NAME}`;
+export const TEST_HOST_NAME = "someHost";
+export const TEST_PROTOCOL = "https";
 export const TEST_TIMESTAMP = 1713537678754;
 export const TEST_DYNAMO_USER = {
     pk: {S: "user#12345"},

--- a/express/tests/constants.ts
+++ b/express/tests/constants.ts
@@ -4,6 +4,12 @@ export const TEST_EMAIL = "someEmail";
 export const TEST_SESSION_ID = "someSessionId";
 export const TEST_IP_ADDRESS = "1.1.1.1";
 export const TEST_PHONE_NUMBER = "+4413456789";
+export const TEST_CURRENT_PASSWORD = "superSecurePassword123";
+export const TEST_NEW_PASSWORD = "superSecurePassword456";
+export const TEST_FIRST_NAME = "firstName";
+export const TEST_LAST_NAME = "lastName";
+export const TEST_FULL_NAME = `${TEST_FIRST_NAME} ${TEST_LAST_NAME}`;
+export const TEST_TIMESTAMP = 1713537678754;
 export const TEST_DYNAMO_USER = {
     pk: {S: "user#12345"},
     phone: {S: TEST_PHONE_NUMBER}
@@ -32,6 +38,16 @@ export const TEST_JWT = JSON.stringify({
     email: TEST_EMAIL,
     scopes: TEST_SCOPES
 });
+
+export const TEST_USER = {
+    id: "12334",
+    fullName: TEST_FULL_NAME,
+    firstName: TEST_FIRST_NAME,
+    lastName: TEST_LAST_NAME,
+    email: TEST_EMAIL,
+    mobileNumber: TEST_PHONE_NUMBER,
+    passwordLastUpdated: "2024-04-19T14:41:18.754Z"
+};
 
 export const constructFakeJwt = (jwtBody: Record<string, unknown>): string =>
     "someHeader." + Buffer.from(JSON.stringify(jwtBody)).toString("base64") + ".someSignature";

--- a/express/tests/controllers/account.test.ts
+++ b/express/tests/controllers/account.test.ts
@@ -1,0 +1,387 @@
+import SelfServiceServicesService from "../../src/services/self-service-services-service";
+import {request, response} from "../mocks";
+import {
+    TEST_AUTHENTICATION_RESULT,
+    TEST_COGNITO_ID,
+    TEST_CURRENT_PASSWORD,
+    TEST_EMAIL,
+    TEST_IP_ADDRESS,
+    TEST_NEW_PASSWORD,
+    TEST_PHONE_NUMBER,
+    TEST_SECURITY_CODE,
+    TEST_SESSION_ID,
+    TEST_TIMESTAMP,
+    TEST_USER
+} from "../constants";
+import {
+    changePassword,
+    processChangePhoneNumberForm,
+    showAccount,
+    showVerifyMobileWithSmsCode,
+    verifyMobileWithSmsCode
+} from "../../src/controllers/account";
+import AuthenticationResultParser from "../../src/lib/authentication-result-parser";
+import {
+    CodeMismatchException,
+    CognitoIdentityProviderServiceException,
+    LimitExceededException,
+    NotAuthorizedException
+} from "@aws-sdk/client-cognito-identity-provider";
+
+describe("showAccount controller tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.useFakeTimers().setSystemTime(TEST_TIMESTAMP);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+    const getSelfServiceUserSpy = jest.spyOn(SelfServiceServicesService.prototype, "getSelfServiceUser");
+    const authenticationResultParserSpy = jest.spyOn(AuthenticationResultParser, "getPhoneNumber");
+
+    it("calls s4 to retrieve the user details and renders the account template", async () => {
+        getSelfServiceUserSpy.mockResolvedValue(TEST_USER);
+        const mockReq = request({
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT
+            }
+        });
+        authenticationResultParserSpy.mockReturnValue(TEST_PHONE_NUMBER);
+        const mockRes = response();
+        const mockNext = jest.fn();
+
+        await showAccount(mockReq, mockRes, mockNext);
+        expect(getSelfServiceUserSpy).toHaveBeenCalledWith(TEST_AUTHENTICATION_RESULT);
+        expect(mockRes.render).toHaveBeenCalledWith("account/account.njk", {
+            emailAddress: TEST_USER.email,
+            mobilePhoneNumber: TEST_USER.mobileNumber,
+            passwordLastChanged: "Last updated just now",
+            serviceName: "My juggling service",
+            updatedField: undefined
+        });
+    });
+});
+
+describe("changePassword controller tests", () => {
+    const s4ChangePasswordSpy = jest.spyOn(SelfServiceServicesService.prototype, "changePassword");
+    const s4UpdateUserSpy = jest.spyOn(SelfServiceServicesService.prototype, "updateUser");
+    const s4SendTxMALogSpy = jest.spyOn(SelfServiceServicesService.prototype, "sendTxMALog");
+    const authenticationResultParserSpy = jest.spyOn(AuthenticationResultParser, "getCognitoId");
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.useFakeTimers().setSystemTime(TEST_TIMESTAMP);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it("calls s4 change the user password and updates the password updated date, sends a TxMA log and then redirects to /account ", async () => {
+        s4ChangePasswordSpy.mockResolvedValue();
+        s4UpdateUserSpy.mockResolvedValue();
+        s4SendTxMALogSpy.mockReturnValue();
+        authenticationResultParserSpy.mockReturnValue(TEST_COGNITO_ID);
+        const mockReq = request({
+            body: {
+                newPassword: TEST_NEW_PASSWORD,
+                currentPassword: TEST_CURRENT_PASSWORD
+            },
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT,
+                id: TEST_SESSION_ID
+            },
+            ip: TEST_IP_ADDRESS
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+        await changePassword(mockReq, mockRes, mockNext);
+        expect(s4ChangePasswordSpy).toHaveBeenCalledWith(TEST_AUTHENTICATION_RESULT.AccessToken, TEST_CURRENT_PASSWORD, TEST_NEW_PASSWORD);
+        expect(s4UpdateUserSpy).toHaveBeenCalledWith(
+            TEST_COGNITO_ID,
+            {
+                password_last_updated: new Date(TEST_TIMESTAMP)
+            },
+            TEST_AUTHENTICATION_RESULT.AccessToken
+        );
+        expect(s4SendTxMALogSpy).toHaveBeenCalledWith("SSE_UPDATE_PASSWORD", {
+            session_id: TEST_SESSION_ID,
+            user_id: TEST_COGNITO_ID,
+            ip_address: TEST_IP_ADDRESS
+        });
+        expect(mockReq.session.updatedField).toStrictEqual("password");
+        expect(mockRes.redirect).toHaveBeenCalledWith("/account");
+    });
+
+    it("renders the change password page with a too many attempts message when s4 throws a LimitExceededException", async () => {
+        s4ChangePasswordSpy.mockRejectedValue(
+            new LimitExceededException({
+                message: "Too many attempts",
+                $metadata: {}
+            })
+        );
+        authenticationResultParserSpy.mockReturnValue(TEST_COGNITO_ID);
+        const mockReq = request({
+            body: {
+                newPassword: TEST_NEW_PASSWORD,
+                currentPassword: TEST_CURRENT_PASSWORD
+            },
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT,
+                id: TEST_SESSION_ID
+            },
+            ip: TEST_IP_ADDRESS
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+        await changePassword(mockReq, mockRes, mockNext);
+        expect(mockRes.render).toHaveBeenCalledWith("account/change-password.njk", {
+            values: {
+                newPassword: TEST_NEW_PASSWORD,
+                currentPassword: TEST_CURRENT_PASSWORD
+            },
+            errorMessages: {
+                newPassword: "You have tried to change your password too many times. Try again in 15 minutes."
+            }
+        });
+    });
+
+    it("renders the change password page with an Incorrect password error message when s4 throws a NotAuthorizedException", async () => {
+        s4ChangePasswordSpy.mockRejectedValue(
+            new NotAuthorizedException({
+                message: "Wrong Password",
+                $metadata: {}
+            })
+        );
+        authenticationResultParserSpy.mockReturnValue(TEST_COGNITO_ID);
+        const mockReq = request({
+            body: {
+                newPassword: TEST_NEW_PASSWORD,
+                currentPassword: TEST_CURRENT_PASSWORD
+            },
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT,
+                id: TEST_SESSION_ID
+            },
+            ip: TEST_IP_ADDRESS
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+        await changePassword(mockReq, mockRes, mockNext);
+        expect(mockRes.render).toHaveBeenCalledWith("account/change-password.njk", {
+            values: {
+                newPassword: TEST_NEW_PASSWORD
+            },
+            errorMessages: {
+                newPassword: "Your current password is incorrect"
+            }
+        });
+    });
+
+    it("throws the error when it is any other kind of CognitoIdentityProviderServiceException", async () => {
+        s4ChangePasswordSpy.mockRejectedValue(
+            new CognitoIdentityProviderServiceException({
+                $fault: "server",
+                name: "someOtherException",
+                $metadata: {httpStatusCode: 500}
+            })
+        );
+        authenticationResultParserSpy.mockReturnValue(TEST_COGNITO_ID);
+        const mockReq = request({
+            body: {
+                newPassword: TEST_NEW_PASSWORD,
+                currentPassword: TEST_CURRENT_PASSWORD
+            },
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT,
+                id: TEST_SESSION_ID
+            },
+            ip: TEST_IP_ADDRESS
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+        await expect(() => changePassword(mockReq, mockRes, mockNext)).rejects.toThrow(CognitoIdentityProviderServiceException);
+    });
+
+    it("throws the error when it is not a  CognitoIdentityProviderServiceException", async () => {
+        const error = "someError";
+        s4ChangePasswordSpy.mockRejectedValue(new Error(error));
+        authenticationResultParserSpy.mockReturnValue(TEST_COGNITO_ID);
+        const mockReq = request({
+            body: {
+                newPassword: TEST_NEW_PASSWORD,
+                currentPassword: TEST_CURRENT_PASSWORD
+            },
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT,
+                id: TEST_SESSION_ID
+            },
+            ip: TEST_IP_ADDRESS
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+        await expect(() => changePassword(mockReq, mockRes, mockNext)).rejects.toThrow(error);
+    });
+});
+
+describe("processChangeNumberForm", () => {
+    const s4SetPhoneNumberSpy = jest.spyOn(SelfServiceServicesService.prototype, "setPhoneNumber");
+    const s4UpdateUserSpy = jest.spyOn(SelfServiceServicesService.prototype, "updateUser");
+    const s4SendVerificationCodeSpy = jest.spyOn(SelfServiceServicesService.prototype, "sendMobileNumberVerificationCode");
+    const s4SendTxMALogSpy = jest.spyOn(SelfServiceServicesService.prototype, "sendTxMALog");
+    const authenticationResultParserEmailSpy = jest.spyOn(AuthenticationResultParser, "getEmail");
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("calls the s4 service with the expected parameters and renders the enter text code page", async () => {
+        authenticationResultParserEmailSpy.mockReturnValue(TEST_EMAIL);
+        s4SetPhoneNumberSpy.mockResolvedValue();
+        s4UpdateUserSpy.mockResolvedValue();
+        s4SendVerificationCodeSpy.mockResolvedValue();
+        s4SendTxMALogSpy.mockReturnValue();
+
+        const mockReq = request({
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT
+            },
+            body: {
+                mobileNumber: TEST_PHONE_NUMBER
+            }
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+
+        await processChangePhoneNumberForm(mockReq, mockRes, mockNext);
+        expect(mockRes.redirect).toHaveBeenCalledWith("/account/change-phone-number/enter-text-code");
+    });
+});
+
+describe("showVerifyMobileWithSmsCode controller tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("calls res.render with the expected values", () => {
+        const mockReq = request({session: {enteredMobileNumber: TEST_PHONE_NUMBER}});
+        const mockRes = response();
+        const mockNext = jest.fn();
+
+        showVerifyMobileWithSmsCode(mockReq, mockRes, mockNext);
+
+        expect(mockRes.render).toHaveBeenCalledWith("common/enter-text-code.njk", {
+            headerActiveItem: "your-account",
+            values: {
+                mobileNumber: TEST_PHONE_NUMBER,
+                textMessageNotReceivedUrl: "/account/change-phone-number/resend-text-code"
+            }
+        });
+    });
+});
+
+describe("verifyMobileWithSmsCode controller tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const s4SendTxMALogSpy = jest.spyOn(SelfServiceServicesService.prototype, "sendTxMALog");
+    const s4VerifyMobileSpy = jest.spyOn(SelfServiceServicesService.prototype, "verifyMobileUsingSmsCode");
+    const s4SetMobilePhoneAsVerifiedSpy = jest.spyOn(SelfServiceServicesService.prototype, "setMobilePhoneAsVerified");
+    const authenticationResultParserEmailSpy = jest.spyOn(AuthenticationResultParser, "getEmail");
+    const authenticationResultParserGetCognitoSpy = jest.spyOn(AuthenticationResultParser, "getCognitoId");
+
+    it("renders the enter text code page with an error message  upon a CodeMismatchException", async () => {
+        s4VerifyMobileSpy.mockRejectedValue(
+            new CodeMismatchException({
+                message: "Incorrect Code",
+                $metadata: {httpStatusCode: 400}
+            })
+        );
+        authenticationResultParserEmailSpy.mockReturnValue(TEST_EMAIL);
+        authenticationResultParserGetCognitoSpy.mockReturnValue(TEST_COGNITO_ID);
+
+        const mockReq = request({
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT,
+                id: TEST_SESSION_ID,
+                enteredMobileNumber: TEST_PHONE_NUMBER
+            },
+            body: {
+                securityCode: TEST_SECURITY_CODE
+            },
+            ip: TEST_IP_ADDRESS
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+
+        await verifyMobileWithSmsCode(mockReq, mockRes, mockNext);
+
+        expect(s4VerifyMobileSpy).toHaveBeenCalledWith(TEST_AUTHENTICATION_RESULT.AccessToken, TEST_SECURITY_CODE, TEST_EMAIL);
+        expect(s4SendTxMALogSpy).toHaveBeenCalledWith(
+            "SSE_PHONE_VERIFICATION_COMPLETE",
+            {
+                session_id: TEST_SESSION_ID,
+                ip_address: TEST_IP_ADDRESS,
+                user_id: TEST_COGNITO_ID,
+                phone: TEST_PHONE_NUMBER
+            },
+            {
+                outcome: "failed"
+            }
+        );
+        expect(mockRes.render).toHaveBeenCalledWith("common/enter-text-code.njk", {
+            headerActiveItem: "your-account",
+            values: {
+                securityCode: TEST_SECURITY_CODE,
+                mobileNumber: TEST_PHONE_NUMBER,
+                textMessageNotReceivedUrl: "/account/change-phone-number/resend-text-code"
+            },
+            errorMessages: {
+                securityCode: "The code you entered is not correct or has expired - enter it again or request a new code"
+            }
+        });
+    });
+
+    it("redirects to /account upon a successful text code verification", async () => {
+        s4VerifyMobileSpy.mockResolvedValue();
+        s4SetMobilePhoneAsVerifiedSpy.mockResolvedValue();
+        authenticationResultParserEmailSpy.mockReturnValue(TEST_EMAIL);
+        authenticationResultParserGetCognitoSpy.mockReturnValue(TEST_COGNITO_ID);
+
+        const mockReq = request({
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT,
+                id: TEST_SESSION_ID,
+                enteredMobileNumber: TEST_PHONE_NUMBER
+            },
+            body: {
+                securityCode: TEST_SECURITY_CODE
+            },
+            ip: TEST_IP_ADDRESS
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+
+        await verifyMobileWithSmsCode(mockReq, mockRes, mockNext);
+
+        expect(s4VerifyMobileSpy).toHaveBeenCalledWith(TEST_AUTHENTICATION_RESULT.AccessToken, TEST_SECURITY_CODE, TEST_EMAIL);
+        expect(s4SetMobilePhoneAsVerifiedSpy).toHaveBeenCalledWith(TEST_EMAIL);
+        expect(mockReq.session.mobileNumber).toStrictEqual(TEST_PHONE_NUMBER);
+        expect(mockReq.session.updatedField).toStrictEqual("mobile phone number");
+        expect(s4SendTxMALogSpy).toHaveBeenCalledWith(
+            "SSE_PHONE_VERIFICATION_COMPLETE",
+            {
+                session_id: TEST_SESSION_ID,
+                ip_address: TEST_IP_ADDRESS,
+                user_id: TEST_COGNITO_ID,
+                phone: TEST_PHONE_NUMBER
+            },
+            {
+                outcome: "success"
+            }
+        );
+        expect(mockRes.redirect).toHaveBeenCalledWith("/account");
+    });
+});

--- a/express/tests/controllers/sign-in.test.ts
+++ b/express/tests/controllers/sign-in.test.ts
@@ -1,0 +1,651 @@
+import {request, response} from "../mocks";
+import {
+    confirmForgotPassword,
+    confirmForgotPasswordForm,
+    confirmPasswordContinueRecovery,
+    finishSignIn,
+    forgotPasswordForm,
+    globalSignOut,
+    organiseDynamoDBForRecoveredUser,
+    processEmailAddress,
+    showCheckPhonePage,
+    checkEmailPasswordReset
+} from "../../src/controllers/sign-in";
+import {
+    TEST_AUTHENTICATION_RESULT,
+    TEST_COGNITO_ID,
+    TEST_CURRENT_PASSWORD,
+    TEST_DYNAMO_USER,
+    TEST_EMAIL,
+    TEST_FULL_NAME,
+    TEST_HOST_NAME,
+    TEST_IP_ADDRESS,
+    TEST_MFA_RESPONSE,
+    TEST_PHONE_NUMBER,
+    TEST_PROTOCOL,
+    TEST_SECURITY_CODE,
+    TEST_SESSION_ID,
+    TEST_TIMESTAMP,
+    TEST_USER
+} from "../constants";
+import {obscureNumber} from "../../src/lib/mobile-number";
+import SelfServiceServicesService from "../../src/services/self-service-services-service";
+import {User} from "../../@types/user";
+import AuthenticationResultParser from "../../src/lib/authentication-result-parser";
+import {AxiosResponse} from "axios";
+import {SignupStatus, SignupStatusStage} from "../../src/lib/utils/signup-status";
+import console from "console";
+import {LimitExceededException, UserNotFoundException} from "@aws-sdk/client-cognito-identity-provider";
+
+describe("showCheckPhonePage controller tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+    it.each(["emailAddress", "mfaResponse"])("redirects to the /sign-in page if the %s session value in session is null", field => {
+        const mockReq = request({
+            session: {
+                [field]: null
+            }
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+        showCheckPhonePage(mockReq, mockRes, mockNext);
+        expect(mockRes.redirect).toHaveBeenCalledWith("/sign-in");
+    });
+
+    it("calls render with the enter text code template and expected render options", () => {
+        const mockReq = request({
+            session: {
+                emailAddress: TEST_EMAIL,
+                mfaResponse: TEST_MFA_RESPONSE
+            }
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+        showCheckPhonePage(mockReq, mockRes, mockNext);
+        expect(mockRes.render).toHaveBeenCalledWith("common/enter-text-code.njk", {
+            headerActiveItem: "sign-in",
+            values: {
+                mobileNumber: obscureNumber(TEST_PHONE_NUMBER),
+                textMessageNotReceivedUrl: "/sign-in/resend-text-code"
+            }
+        });
+    });
+});
+
+describe("confirmPasswordContinueRecovery controller tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("calls render with the expected template path", () => {
+        const mockReq = response();
+        confirmPasswordContinueRecovery(request(), mockReq, jest.fn());
+        expect(mockReq.redirect).toHaveBeenCalledWith("/sign-in/forgot-password/continue-recovery");
+    });
+});
+
+describe("finishSignIn controller tests", () => {
+    const s4GetSelfServiceUserSpy = jest.spyOn(SelfServiceServicesService.prototype, "getSelfServiceUser");
+    const s4UpdateUserSpy = jest.spyOn(SelfServiceServicesService.prototype, "updateUser");
+    const getCognitoSpy = jest.spyOn(AuthenticationResultParser, "getCognitoId");
+    const s4SessionCount = jest.spyOn(SelfServiceServicesService.prototype, "sessionCount");
+    const s4SendTxMALogSpy = jest.spyOn(SelfServiceServicesService.prototype, "sendTxMALog");
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.useFakeTimers().setSystemTime(TEST_TIMESTAMP);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it("redirects to /sign-in/enter-text-code if s4 does not return a user", async () => {
+        s4GetSelfServiceUserSpy.mockResolvedValue(null as unknown as User);
+
+        const mockReq = request({
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT
+            }
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+        await finishSignIn(mockReq, mockRes, mockNext);
+        expect(s4GetSelfServiceUserSpy).toHaveBeenCalledWith(TEST_AUTHENTICATION_RESULT);
+        expect(mockRes.redirect).toHaveBeenCalledWith("/sign-in/enter-text-code");
+    });
+
+    it("calls s4 updateUser if the session updatedField is password", async () => {
+        s4GetSelfServiceUserSpy.mockResolvedValue(TEST_USER);
+        s4UpdateUserSpy.mockResolvedValue();
+        getCognitoSpy.mockReturnValue(TEST_COGNITO_ID);
+        s4SessionCount.mockResolvedValue(1);
+        s4SendTxMALogSpy.mockReturnValue();
+
+        const mockReq = request({
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT,
+                updatedField: "password"
+            }
+        });
+
+        const mockRes = response();
+        const mockNext = jest.fn();
+
+        await finishSignIn(mockReq, mockRes, mockNext);
+
+        expect(s4GetSelfServiceUserSpy).toHaveBeenCalledWith(TEST_AUTHENTICATION_RESULT);
+        expect(s4UpdateUserSpy).toHaveBeenCalledWith(
+            TEST_COGNITO_ID,
+            {password_last_updated: new Date(TEST_TIMESTAMP)},
+            TEST_AUTHENTICATION_RESULT.AccessToken
+        );
+    });
+
+    it("redirects to /sign-in/signed-in-to-another-device if the session count is > 1", async () => {
+        s4GetSelfServiceUserSpy.mockResolvedValue(TEST_USER);
+        s4UpdateUserSpy.mockResolvedValue();
+        s4SessionCount.mockResolvedValue(3);
+
+        const mockReq = request({
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT
+            }
+        });
+
+        const mockRes = response();
+        const mockNext = jest.fn();
+
+        await finishSignIn(mockReq, mockRes, mockNext);
+
+        expect(s4GetSelfServiceUserSpy).toHaveBeenCalledWith(TEST_AUTHENTICATION_RESULT);
+        expect(s4UpdateUserSpy).not.toHaveBeenCalled();
+        expect(mockReq.session.isSignedIn).toBe(true);
+        expect(mockRes.redirect).toHaveBeenCalledWith("/sign-in/signed-in-to-another-device");
+    });
+
+    it("sends two txma logs and redirects to /services when the session count is 1", async () => {
+        s4GetSelfServiceUserSpy.mockResolvedValue(TEST_USER);
+        s4UpdateUserSpy.mockResolvedValue();
+        s4SessionCount.mockResolvedValue(1);
+        getCognitoSpy.mockReturnValue(TEST_COGNITO_ID);
+        s4SendTxMALogSpy.mockReturnValue();
+
+        const mockReq = request({
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT,
+                id: TEST_SESSION_ID
+            },
+            ip: TEST_IP_ADDRESS
+        });
+
+        const mockRes = response();
+        const mockNext = jest.fn();
+
+        await finishSignIn(mockReq, mockRes, mockNext);
+
+        expect(s4GetSelfServiceUserSpy).toHaveBeenCalledWith(TEST_AUTHENTICATION_RESULT);
+        expect(s4UpdateUserSpy).not.toHaveBeenCalled();
+        expect(mockReq.session.isSignedIn).toBe(true);
+        expect(s4SendTxMALogSpy).toHaveBeenCalledWith("SSE_LOG_IN_SUCCESS", {
+            session_id: TEST_SESSION_ID,
+            ip_address: TEST_IP_ADDRESS,
+            user_id: TEST_COGNITO_ID,
+            email: TEST_EMAIL
+        });
+        expect(s4SendTxMALogSpy).toHaveBeenCalledWith(
+            "SSE_PHONE_VERIFICATION_COMPLETE",
+            {
+                session_id: TEST_SESSION_ID,
+                ip_address: TEST_IP_ADDRESS,
+                user_id: TEST_COGNITO_ID,
+                email: TEST_EMAIL
+            },
+            {
+                outcome: "success"
+            }
+        );
+        expect(mockRes.redirect).toHaveBeenCalledWith("/services");
+    });
+});
+
+describe("globalSignOut controller tests", () => {
+    const s4GetSelfServiceUserSpy = jest.spyOn(SelfServiceServicesService.prototype, "getSelfServiceUser");
+    const s4GlobalSignOutSpy = jest.spyOn(SelfServiceServicesService.prototype, "globalSignOut");
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+    it("calls s4 for user and global sign out if access token is present and then destroys the session", async () => {
+        s4GetSelfServiceUserSpy.mockResolvedValue(TEST_USER);
+        s4GlobalSignOutSpy.mockResolvedValue({status: 200} as AxiosResponse);
+
+        const mockReq = request({
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT,
+                destroy: jest.fn().mockImplementation(arg => arg())
+            }
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+
+        await globalSignOut(mockReq, mockRes, mockNext);
+        expect(s4GetSelfServiceUserSpy).toHaveBeenCalledWith(TEST_AUTHENTICATION_RESULT);
+        expect(s4GlobalSignOutSpy).toHaveBeenCalledWith(TEST_EMAIL, TEST_AUTHENTICATION_RESULT.AccessToken);
+        expect(mockReq.session.destroy).toHaveBeenCalledWith(expect.any(Function));
+        expect(mockRes.redirect).toHaveBeenCalledWith("/sign-in/enter-email-address-global-sign-out");
+    });
+
+    it("calls only destroy session if there is no access token present", async () => {
+        const mockRes = response();
+        const mockReq = request({
+            session: {
+                authenticationResult: {...TEST_AUTHENTICATION_RESULT, AccessToken: null},
+                destroy: jest.fn().mockImplementation(arg => arg())
+            }
+        });
+        const mockNext = jest.fn();
+
+        await globalSignOut(mockReq, mockRes, mockNext);
+        expect(s4GetSelfServiceUserSpy).not.toHaveBeenCalled();
+        expect(s4GlobalSignOutSpy).not.toHaveBeenCalled();
+        expect(mockReq.session.destroy).toHaveBeenCalledWith(expect.any(Function));
+        expect(mockRes.redirect).toHaveBeenCalledWith("/sign-in/enter-email-address-global-sign-out");
+    });
+});
+
+describe("processEmailAddress controller tests", () => {
+    const s4GetSignUpStatusSpy = jest.spyOn(SelfServiceServicesService.prototype, "getSignUpStatus");
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.spyOn(console, "info");
+    });
+
+    it("calls s4 get to get the sign up status and redirects to /register/resume-before-password if there is no email", async () => {
+        s4GetSignUpStatusSpy.mockResolvedValue(new SignupStatus());
+
+        const mockReq = request({
+            session: {
+                emailAddress: TEST_EMAIL
+            }
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+
+        await processEmailAddress(mockReq, mockRes, mockNext);
+
+        expect(s4GetSignUpStatusSpy).toHaveBeenCalledWith(TEST_EMAIL);
+        expect(console.info).toHaveBeenCalledWith("Processing No HasEMail");
+        expect(mockRes.redirect).toHaveBeenCalledWith("/register/resume-before-password");
+    });
+
+    it("calls s4 get to get the sign up status and redirects to /register/resume-before-password if the password stage hasn't been reached", async () => {
+        const mockSignUpStatus = new SignupStatus();
+        mockSignUpStatus.setStage(SignupStatusStage.HasEmail, true);
+        s4GetSignUpStatusSpy.mockResolvedValue(mockSignUpStatus);
+
+        const mockReq = request({
+            session: {
+                emailAddress: TEST_EMAIL
+            }
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+
+        await processEmailAddress(mockReq, mockRes, mockNext);
+
+        expect(s4GetSignUpStatusSpy).toHaveBeenCalledWith(TEST_EMAIL);
+        expect(console.info).toHaveBeenCalledWith("Processing No HasPassword");
+        expect(mockRes.redirect).toHaveBeenCalledWith("/register/resume-before-password");
+    });
+
+    it("calls s4 get to get the sign up status and redirects to /register/resume-after-password if there is no phone number", async () => {
+        const mockSignUpStatus = new SignupStatus();
+        mockSignUpStatus.setStage(SignupStatusStage.HasEmail, true);
+        mockSignUpStatus.setStage(SignupStatusStage.HasPassword, true);
+        s4GetSignUpStatusSpy.mockResolvedValue(mockSignUpStatus);
+
+        const mockReq = request({
+            session: {
+                emailAddress: TEST_EMAIL
+            }
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+
+        await processEmailAddress(mockReq, mockRes, mockNext);
+
+        expect(s4GetSignUpStatusSpy).toHaveBeenCalledWith(TEST_EMAIL);
+        expect(console.info).toHaveBeenCalledWith("Processing No HasPhoneNumber");
+        expect(mockRes.redirect).toHaveBeenCalledWith("/register/resume-after-password");
+    });
+
+    it("calls s4 get to get the sign up status and redirects to /register/resume-after-password if there is no text code", async () => {
+        const mockSignUpStatus = new SignupStatus();
+        mockSignUpStatus.setStage(SignupStatusStage.HasEmail, true);
+        mockSignUpStatus.setStage(SignupStatusStage.HasPassword, true);
+        mockSignUpStatus.setStage(SignupStatusStage.HasPhoneNumber, true);
+        s4GetSignUpStatusSpy.mockResolvedValue(mockSignUpStatus);
+
+        const mockReq = request({
+            session: {
+                emailAddress: TEST_EMAIL
+            }
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+
+        await processEmailAddress(mockReq, mockRes, mockNext);
+
+        expect(s4GetSignUpStatusSpy).toHaveBeenCalledWith(TEST_EMAIL);
+        expect(console.info).toHaveBeenCalledWith("Processing No HasTextCode");
+        expect(mockRes.redirect).toHaveBeenCalledWith("/register/resume-after-password");
+    });
+
+    it("calls s4 get to get the sign up status and redirects to /sign-in/enter-password if all stages are present", async () => {
+        const mockSignUpStatus = new SignupStatus();
+        mockSignUpStatus.setStage(SignupStatusStage.HasEmail, true);
+        mockSignUpStatus.setStage(SignupStatusStage.HasPassword, true);
+        mockSignUpStatus.setStage(SignupStatusStage.HasPhoneNumber, true);
+        mockSignUpStatus.setStage(SignupStatusStage.HasTextCode, true);
+        s4GetSignUpStatusSpy.mockResolvedValue(mockSignUpStatus);
+
+        const mockReq = request({
+            session: {
+                emailAddress: TEST_EMAIL
+            }
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+
+        await processEmailAddress(mockReq, mockRes, mockNext);
+
+        expect(s4GetSignUpStatusSpy).toHaveBeenCalledWith(TEST_EMAIL);
+        expect(mockRes.redirect).toHaveBeenCalledWith("/sign-in/enter-password");
+    });
+
+    it("redirects to /sign-in/enter-password if s4 throws an error", async () => {
+        s4GetSignUpStatusSpy.mockRejectedValue(new Error("someError"));
+
+        const mockReq = request({
+            session: {
+                emailAddress: TEST_EMAIL
+            }
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+
+        await processEmailAddress(mockReq, mockRes, mockNext);
+
+        expect(s4GetSignUpStatusSpy).toHaveBeenCalledWith(TEST_EMAIL);
+        expect(mockRes.redirect).toHaveBeenCalledWith("/sign-in/enter-password");
+    });
+});
+
+describe("forgotPasswordForm controller tests", () => {
+    const s4SendTxMALogSpy = jest.spyOn(SelfServiceServicesService.prototype, "sendTxMALog");
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("sends a txma log and renders the /sign-in/forgot-password template with the email address in the options", async () => {
+        s4SendTxMALogSpy.mockReturnValue();
+
+        const mockReq = request({
+            session: {
+                id: TEST_SESSION_ID,
+                emailAddress: TEST_EMAIL
+            },
+            ip: TEST_IP_ADDRESS
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+
+        await forgotPasswordForm(mockReq, mockRes, mockNext);
+
+        expect(s4SendTxMALogSpy).toHaveBeenCalledWith("SSE_PASSWORD_RESET_REQUESTED", {
+            email: TEST_EMAIL,
+            session_id: TEST_SESSION_ID,
+            ip_address: TEST_IP_ADDRESS
+        });
+        expect(mockRes.render).toHaveBeenCalledWith("sign-in/forgot-password.njk", {
+            values: {
+                emailAddress: TEST_EMAIL
+            }
+        });
+    });
+});
+
+describe("confirmForgotPasswordForm controller tests", () => {
+    it("renders the /sign-in/create-new-password template with the expected values", () => {
+        const mockReq = request({
+            query: {
+                loginName: TEST_FULL_NAME,
+                confirmationCode: TEST_SECURITY_CODE
+            }
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+
+        confirmForgotPasswordForm(mockReq, mockRes, mockNext);
+        expect(mockRes.render).toHaveBeenCalledWith("sign-in/create-new-password.njk", {
+            loginName: TEST_FULL_NAME,
+            confirmationCode: TEST_SECURITY_CODE
+        });
+    });
+});
+
+describe("confirmForgotPassword controller tests", () => {
+    const s4ConfirmForgotPasswordSpy = jest.spyOn(SelfServiceServicesService.prototype, "confirmForgotPassword");
+    const s4SendTxMALogSpy = jest.spyOn(SelfServiceServicesService.prototype, "sendTxMALog");
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+    it("handles a LimitExceededException and renders the /sign-in/create-new-password template with an error message", async () => {
+        s4ConfirmForgotPasswordSpy.mockRejectedValue(
+            new LimitExceededException({
+                $metadata: {httpStatusCode: 400},
+                message: "Too Many requests"
+            })
+        );
+
+        const mockReq = request({
+            body: {
+                loginName: TEST_EMAIL,
+                password: TEST_CURRENT_PASSWORD,
+                confirmationCode: TEST_SECURITY_CODE
+            }
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+        await confirmForgotPassword(mockReq, mockRes, mockNext);
+        expect(s4ConfirmForgotPasswordSpy).toHaveBeenCalledWith(TEST_EMAIL, TEST_CURRENT_PASSWORD, TEST_SECURITY_CODE);
+        expect(mockRes.render).toHaveBeenCalledWith("sign-in/create-new-password.njk", {
+            errorMessages: {
+                password: "You have tried to change your password too many times. Try again in 15 minutes."
+            },
+            values: {
+                password: TEST_CURRENT_PASSWORD
+            }
+        });
+    });
+
+    it("throws any s4 errors which are not LimitExceededException", async () => {
+        s4ConfirmForgotPasswordSpy.mockRejectedValue(new Error("someError"));
+
+        const mockReq = request({
+            body: {
+                loginName: TEST_EMAIL,
+                password: TEST_CURRENT_PASSWORD,
+                confirmationCode: TEST_SECURITY_CODE
+            }
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+        await expect(confirmForgotPassword(mockReq, mockRes, mockNext)).rejects.toThrow();
+        expect(s4ConfirmForgotPasswordSpy).toHaveBeenCalledWith(TEST_EMAIL, TEST_CURRENT_PASSWORD, TEST_SECURITY_CODE);
+        expect(mockRes.render).not.toHaveBeenCalled();
+    });
+
+    it("sends a txma log and calls next() when the confirm password forgot call is successful", async () => {
+        s4ConfirmForgotPasswordSpy.mockResolvedValue();
+        s4SendTxMALogSpy.mockReturnValue();
+
+        const mockReq = request({
+            body: {
+                loginName: TEST_EMAIL,
+                password: TEST_CURRENT_PASSWORD,
+                confirmationCode: TEST_SECURITY_CODE
+            },
+            session: {
+                id: TEST_SESSION_ID
+            },
+            ip: TEST_IP_ADDRESS
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+        await confirmForgotPassword(mockReq, mockRes, mockNext);
+        expect(mockReq.session.emailAddress).toStrictEqual(TEST_EMAIL);
+        expect(mockReq.session.updatedField).toStrictEqual("password");
+        expect(s4SendTxMALogSpy).toHaveBeenCalledWith("SSE_PASSWORD_RESET_COMPLETED", {
+            email: TEST_EMAIL,
+            session_id: TEST_SESSION_ID,
+            ip_address: TEST_IP_ADDRESS
+        });
+        expect(mockNext).toHaveBeenCalled();
+    });
+});
+
+describe("organiseDynamoDBForRecoveredUser controller tests", () => {
+    const s4RecreateDynamoDBAccountLinksSpy = jest.spyOn(SelfServiceServicesService.prototype, "recreateDynamoDBAccountLinks");
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("calls s4 recreateDynamoDBAccountLinks with the expected values and then calls next()", async () => {
+        s4RecreateDynamoDBAccountLinksSpy.mockResolvedValue();
+        const mockReq = request({
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT,
+                cognitoID: TEST_COGNITO_ID
+            }
+        });
+        const mockNext = jest.fn();
+        await organiseDynamoDBForRecoveredUser(mockReq, response(), mockNext);
+        expect(s4RecreateDynamoDBAccountLinksSpy).toHaveBeenCalledWith(TEST_AUTHENTICATION_RESULT, TEST_COGNITO_ID);
+        expect(mockNext).toHaveBeenCalled();
+    });
+});
+
+describe("checkEmailPasswordReset controller tests", () => {
+    const s4ForgotPasswordSpy = jest.spyOn(SelfServiceServicesService.prototype, "forgotPassword");
+    const s4GetDynamoDbEntriesSpy = jest.spyOn(SelfServiceServicesService.prototype, "getDynamoDBEntries");
+    const s4RecoverCognitoSpy = jest.spyOn(SelfServiceServicesService.prototype, "recoverCognitoAccount");
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("calls s4 forgotPassword and calls render with the /sign-in/enter-email-code template", async () => {
+        s4ForgotPasswordSpy.mockResolvedValue();
+        const mockReq = request({
+            session: {
+                emailAddress: TEST_EMAIL
+            },
+            hostname: TEST_HOST_NAME,
+            protocol: TEST_PROTOCOL
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+        await checkEmailPasswordReset(mockReq, mockRes, mockNext);
+        expect(s4ForgotPasswordSpy).toHaveBeenCalledWith(TEST_EMAIL, TEST_PROTOCOL, TEST_HOST_NAME, false);
+        expect(mockRes.render).toHaveBeenCalledWith("sign-in/enter-email-code.njk");
+    });
+
+    it("calls s4 forgotPassword and handles a UserNotFoundException", async () => {
+        s4ForgotPasswordSpy.mockRejectedValueOnce(
+            new UserNotFoundException({
+                $metadata: {httpStatusCode: 400},
+                message: "User not found"
+            })
+        );
+        s4GetDynamoDbEntriesSpy.mockResolvedValue({data: TEST_DYNAMO_USER} as AxiosResponse);
+        s4RecoverCognitoSpy.mockResolvedValue();
+
+        const mockReq = request({
+            session: {
+                emailAddress: TEST_EMAIL
+            },
+            hostname: TEST_HOST_NAME,
+            protocol: TEST_PROTOCOL
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+        await checkEmailPasswordReset(mockReq, mockRes, mockNext);
+        expect(s4ForgotPasswordSpy).toHaveBeenNthCalledWith(1, TEST_EMAIL, TEST_PROTOCOL, TEST_HOST_NAME, false);
+        expect(s4RecoverCognitoSpy).toHaveBeenCalledWith(mockReq, TEST_EMAIL, "recovered", TEST_PHONE_NUMBER);
+        expect(s4ForgotPasswordSpy).toHaveBeenNthCalledWith(2, TEST_EMAIL, TEST_PROTOCOL, TEST_HOST_NAME, true);
+        expect(mockRes.render).toHaveBeenCalledWith("sign-in/enter-email-code.njk");
+    });
+
+    it("calls s4 forgotPassword and handles a UserNotFoundException where no dynamo response is found", async () => {
+        s4ForgotPasswordSpy.mockRejectedValueOnce(
+            new UserNotFoundException({
+                $metadata: {httpStatusCode: 400},
+                message: "User not found"
+            })
+        );
+        s4GetDynamoDbEntriesSpy.mockResolvedValue({data: undefined} as AxiosResponse);
+        s4RecoverCognitoSpy.mockResolvedValue();
+
+        const mockReq = request({
+            session: {
+                emailAddress: TEST_EMAIL
+            },
+            hostname: TEST_HOST_NAME,
+            protocol: TEST_PROTOCOL
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+        await checkEmailPasswordReset(mockReq, mockRes, mockNext);
+        expect(s4ForgotPasswordSpy).toHaveBeenNthCalledWith(1, TEST_EMAIL, TEST_PROTOCOL, TEST_HOST_NAME, false);
+        expect(s4RecoverCognitoSpy).not.toHaveBeenCalled();
+        expect(s4ForgotPasswordSpy).toHaveBeenCalledTimes(1);
+        expect(mockReq.session.emailAddress).toStrictEqual(TEST_EMAIL);
+        expect(mockRes.redirect).toHaveBeenCalledWith("/sign-in/account-not-found");
+    });
+
+    it("calls s4 forgotPassword and handles a LimitExceededException", async () => {
+        s4ForgotPasswordSpy.mockRejectedValueOnce(
+            new LimitExceededException({
+                $metadata: {httpStatusCode: 400},
+                message: "Too many requests"
+            })
+        );
+
+        const mockReq = request({
+            session: {
+                emailAddress: TEST_EMAIL
+            },
+            hostname: TEST_HOST_NAME,
+            protocol: TEST_PROTOCOL
+        });
+        const mockRes = response();
+        const mockNext = jest.fn();
+        await checkEmailPasswordReset(mockReq, mockRes, mockNext);
+        expect(s4ForgotPasswordSpy).toHaveBeenCalledWith(TEST_EMAIL, TEST_PROTOCOL, TEST_HOST_NAME, false);
+        expect(mockRes.render).toHaveBeenCalledWith("sign-in/enter-email-address.njk", {
+            values: {
+                emailAddress: TEST_EMAIL
+            },
+            errorMessages: {
+                emailAddress: "You have tried to change your password too many times. Try again in 15 minutes."
+            }
+        });
+    });
+});

--- a/express/tests/middleware/process-sign-in-form.test.ts
+++ b/express/tests/middleware/process-sign-in-form.test.ts
@@ -8,7 +8,7 @@ jest.mock("../../src/lib/fixedOTP", () => ({
 }));
 
 import processSignInForm from "../../src/middleware/process-sign-in-form";
-import {mockCogntioInterface, mockLambdaFacade, request, response} from "../mocks";
+import {request, response} from "../mocks";
 import {NotAuthorizedException, UserNotFoundException} from "@aws-sdk/client-cognito-identity-provider";
 import SelfServiceServicesService from "../../src/services/self-service-services-service";
 import {AxiosResponse} from "axios";
@@ -46,9 +46,6 @@ describe("processSignInForm tests", () => {
                 },
                 body: {
                     password: password
-                },
-                app: {
-                    get: () => new SelfServiceServicesService(mockCogntioInterface, mockLambdaFacade)
                 }
             });
             const mockResponse = response();
@@ -77,9 +74,6 @@ describe("processSignInForm tests", () => {
             },
             body: {
                 password: TEST_PASSWORD
-            },
-            app: {
-                get: () => new SelfServiceServicesService(mockCogntioInterface, mockLambdaFacade)
             },
             ip: TEST_IP_ADDRESS
         });
@@ -119,10 +113,7 @@ describe("processSignInForm tests", () => {
             body: {
                 password: TEST_PASSWORD
             },
-            ip: TEST_IP_ADDRESS,
-            app: {
-                get: () => new SelfServiceServicesService(mockCogntioInterface, mockLambdaFacade)
-            }
+            ip: TEST_IP_ADDRESS
         });
         const mockResponse = response();
         const processSignInFormMiddleware = processSignInForm(TEST_TEMPLATE_PATH);
@@ -143,10 +134,7 @@ describe("processSignInForm tests", () => {
             body: {
                 password: TEST_PASSWORD
             },
-            ip: TEST_IP_ADDRESS,
-            app: {
-                get: () => new SelfServiceServicesService(mockCogntioInterface, mockLambdaFacade)
-            }
+            ip: TEST_IP_ADDRESS
         });
         const mockResponse = response();
         const processSignInFormMiddleware = processSignInForm(TEST_TEMPLATE_PATH);
@@ -168,10 +156,7 @@ describe("processSignInForm tests", () => {
             body: {
                 password: TEST_PASSWORD
             },
-            ip: TEST_IP_ADDRESS,
-            app: {
-                get: () => new SelfServiceServicesService(mockCogntioInterface, mockLambdaFacade)
-            }
+            ip: TEST_IP_ADDRESS
         });
         const mockResponse = response();
         const processSignInFormMiddleware = processSignInForm(TEST_TEMPLATE_PATH);

--- a/express/tests/middleware/sign-in-middleware.test.ts
+++ b/express/tests/middleware/sign-in-middleware.test.ts
@@ -121,9 +121,6 @@ describe("processSecurityCode tests", () => {
                 id: TEST_SESSION_ID,
                 mobileNumber: TEST_PHONE_NUMBER
             },
-            app: {
-                get: () => new SelfServiceServicesService(mockCogntioInterface, mockLambdaFacade)
-            },
             body: {
                 securityCode: TEST_SECURITY_CODE
             },
@@ -172,9 +169,6 @@ describe("processSecurityCode tests", () => {
                 id: TEST_SESSION_ID,
                 mobileNumber: TEST_PHONE_NUMBER
             },
-            app: {
-                get: () => new SelfServiceServicesService(mockCogntioInterface, mockLambdaFacade)
-            },
             body: {
                 securityCode: TEST_SECURITY_CODE
             },
@@ -207,9 +201,6 @@ describe("processSecurityCode tests", () => {
                 password: TEST_PASSWORD,
                 id: TEST_SESSION_ID,
                 mobileNumber: TEST_PHONE_NUMBER
-            },
-            app: {
-                get: () => new SelfServiceServicesService(mockCogntioInterface, mockLambdaFacade)
             },
             body: {
                 securityCode: TEST_SECURITY_CODE

--- a/express/tests/mocks.ts
+++ b/express/tests/mocks.ts
@@ -1,6 +1,7 @@
 import {Request, Response} from "express";
 import CognitoInterface from "../src/services/cognito/CognitoInterface";
 import LambdaFacadeInterface from "../src/services/lambda-facade/LambdaFacadeInterface";
+import SelfServiceServicesService from "../src/services/self-service-services-service";
 
 export const mockLambdaFacade: LambdaFacadeInterface = {
     sendTxMALog: jest.fn(),
@@ -45,7 +46,18 @@ export const mockCogntioInterface: CognitoInterface = {
     globalSignOut: jest.fn()
 };
 
-export const request = (properties?: Partial<Request> | object) => ({body: {}, session: {}, params: {}, ...properties} as Request);
+export const request = (properties?: Partial<Request> | object) =>
+    ({
+        body: {},
+        session: {},
+        app: {
+            get: (keyName: string) => {
+                if (keyName === "backing-service") return new SelfServiceServicesService(mockCogntioInterface, mockLambdaFacade);
+            }
+        },
+        params: {},
+        ...properties
+    } as Request);
 
 export const response = (properties?: Partial<Response>) =>
     ({render: jest.fn(), redirect: jest.fn(), locals: {}, ...properties} as Partial<Response> as Response);


### PR DESCRIPTION
## BAU: Adding Frontend Unit test coverage
> [!NOTE]  
> This PR makes two small production code changes in the following commits: [FIX: Adds errorMessages object](https://github.com/govuk-one-login/onboarding-self-service-experience/pull/708/commits/b4858d5f14e221558ff7b7ddc9dc109480fd73e2), and here [FIX: Adds errorMessages to the options object used in error handling](https://github.com/govuk-one-login/onboarding-self-service-experience/pull/708/commits/38eb76b86fceaf6a0efc5a562a213f8ad27e8fe0). 

### This PR Adds:
- Unit tests where they are missing for the `sign-in.ts` and `account.ts` controllers
- Two small code changes in the `changePassword` controller and `forgotPassword` controller. These add an errorMessages property on an options object to resolve a runtime TypeError

### This PR Modifies:
- Some of the existing Unit tests as I have moved the mock S4 instance into the main request mock instead of creating one each time a mock request is created 

### This PR Removes:
- N/A


