### PR TITLE
SSE-3275: Update dependabot config for NPM workspaces

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,10 @@ updates:
     schedule:
       interval: daily
     labels:
-      - common
       - dependabot
     commit-message:
       prefix: "BAU"
+    versioning-strategy: increase
     groups:
       prod-dependencies:
         applies-to: version-updates
@@ -16,83 +16,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-  - package-ecosystem: npm
-    directory: /backend/api
-    schedule:
-      interval: daily
-    labels:
-      - api
-      - dependabot
-    commit-message:
-      prefix: "BAU"
-    groups:
-      api-dependencies:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-  - package-ecosystem: npm
-    directory: /backend/api/tests/contract-tests
-    schedule:
-      interval: daily
-    labels:
-      - contact-tests
-      - dependabot
-    commit-message:
-      prefix: "BAU"
-    groups:
-      api-test-dependencies:
-        applies-to: version-updates
-        patterns:
-          - "*"
-  - package-ecosystem: npm
-    directory: /backend/cognito
-    schedule:
-      interval: daily
-    labels:
-      - cognito
-      - dependabot
-    commit-message:
-      prefix: "BAU"
-    groups:
-      cognito-dependencies:
-        applies-to: version-updates
-        dependency-type: "production"
-        update-types:
-          - "minor"
-          - "patch"
-  - package-ecosystem: npm
-    directory: /express
-    schedule:
-      interval: daily
-    labels:
-      - express
-      - dependabot
-    commit-message:
-      prefix: "BAU"
-    groups:
-      frontend-dependencies:
-        applies-to: version-updates
-        dependency-type: "production"
-        update-types:
-          - "minor"
-          - "patch"
-  - package-ecosystem: npm
-    directory: /ui-automation-tests
-    schedule:
-      interval: daily
-    labels:
-      - ui-tests
-      - dependabot
-    commit-message:
-      prefix: "BAU"
-    groups:
-      test-dependencies:
-        applies-to: version-updates
-        patterns:
-          - "*"
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
As described in https://github.com/dependabot/dependabot-core/issues/5226

The previous dependabot config dig not update the package-lock file