### PR TITLE
Ato 1022 fix update service access

### DIFF
--- a/backend/api/api.template.yml
+++ b/backend/api/api.template.yml
@@ -946,6 +946,9 @@ Resources:
       Policies:
         - AWSLambdaVPCAccessExecutionRole
         - AWSXrayWriteOnlyAccess
+        - DynamoDBReadPolicy:
+            TableName:
+              Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
         - Version: 2012-10-17
           Statement:
             - Effect: Allow
@@ -954,6 +957,8 @@ Resources:
       Environment:
         Variables:
           STATE_MACHINE_ARN: !Ref UpdateServiceStepFunction
+          TABLE:
+            Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
       Events:
         Api:
           Type: Api

--- a/backend/api/src/handlers/helper/validate-authorisation-header.ts
+++ b/backend/api/src/handlers/helper/validate-authorisation-header.ts
@@ -1,0 +1,60 @@
+export const validateAuthorisationHeader = (
+    authHeader: string | undefined
+):
+    | {
+          valid: true;
+          userId: string;
+      }
+    | {
+          valid: false;
+          errorResponse: {
+              statusCode: number;
+              body: string;
+          };
+      } => {
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+        return {
+            valid: false,
+            errorResponse: {
+                statusCode: 401,
+                body: "Missing access token"
+            }
+        };
+    }
+
+    const authToken = authHeader.substring(7);
+    //We trust the signature as this token is attached from
+    //the frontend which does the validation
+    const tokenParts = authToken.split(".");
+
+    if (tokenParts.length !== 3) {
+        return {
+            valid: false,
+            errorResponse: {
+                statusCode: 400,
+                body: "Invalid access token"
+            }
+        };
+    }
+
+    const encodedPayload = tokenParts[1];
+    const decodedPayload = Buffer.from(encodedPayload, "base64url").toString("utf-8");
+    const parsedPayload = JSON.parse(decodedPayload);
+
+    const subjectClaim = parsedPayload.sub;
+
+    if (typeof subjectClaim !== "string") {
+        return {
+            valid: false,
+            errorResponse: {
+                statusCode: 400,
+                body: "Invalid access token"
+            }
+        };
+    }
+
+    return {
+        valid: true,
+        userId: subjectClaim
+    };
+};

--- a/backend/api/src/handlers/step-functions/update-service.ts
+++ b/backend/api/src/handlers/step-functions/update-service.ts
@@ -1,6 +1,45 @@
 import {APIGatewayProxyEvent, APIGatewayProxyResult, Context} from "aws-lambda";
 import {stepFunctionHandler} from "./step-function-handler";
+import {validateAuthorisationHeader} from "../helper/validate-authorisation-header";
+import DynamoDbClient from "../../dynamodb-client";
+
+type ClientUpdates = Record<string, string | string[] | boolean>;
+
+export type UpdateServiceBody = {
+    serviceId?: string;
+    selfServiceClientId: string;
+    clientId: string;
+    updates: ClientUpdates;
+};
+
+const client = new DynamoDbClient();
 
 export const doUpdateServiceHandler = async (event: APIGatewayProxyEvent, context: Context): Promise<APIGatewayProxyResult> => {
+    if (!event.body) {
+        return {statusCode: 400, body: "Invalid Request, missing body"};
+    }
+
+    const updateServiceBody: UpdateServiceBody = JSON.parse(event.body);
+    const serviceId = updateServiceBody.serviceId;
+
+    if (!serviceId) {
+        return {statusCode: 400, body: "Invalid Request, missing service ID"};
+    }
+
+    const authHeaderValidationResult = validateAuthorisationHeader(event.headers.Authorization);
+
+    if (!authHeaderValidationResult.valid) {
+        return authHeaderValidationResult.errorResponse;
+    }
+
+    const isUserAuthorised = await client.checkServiceUserExists(serviceId, authHeaderValidationResult.userId);
+
+    if (!isUserAuthorised) {
+        return {
+            statusCode: 403,
+            body: "Forbidden"
+        };
+    }
+
     return stepFunctionHandler(event, context);
 };

--- a/backend/api/tests/handlers/constants.ts
+++ b/backend/api/tests/handlers/constants.ts
@@ -21,6 +21,7 @@ export const TEST_USER_CONFIG: Record<string, AttributeValue> = {
 };
 export const TEST_COGNITO_USER_ID = "e20b814d-55b1-4e68-a28d-3a0c4818adfa";
 export const TEST_SERVICE_ID = "488c26e5-6147-4b8e-be05-031e00310fdb";
+export const TEST_SELF_SERVICE_CLIENT_ID = "128c26e5-6147-4b4e-be15-031e00310gyj";
 export const TEST_DEFAULT_PUBLIC_KEY =
     "MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAp2mLkQGo24Kz1rut0oZlviMkGomlQCH+iT1pFvegZFXq39NPjRWyatmXp/XIUPqCq9Kk8/+tq4Sgjw+EM5tATJ06j5r+35of58ATGVPniW//IhGizrv6/ebGcGEUJ0Y/ZmlCHYPV+lbewpttQ/IYKM1nr3k/Rl6qepbVYe+MpGubluQvdhgUYel9OzxiOvUk7XI0axPquiXzoEgmNNOai8+WhYTkBqE3/OucAv+XwXdnx4XHmKzMwTv93dYMpUmvTxWcSeEJ/4/SrbiK4PyHWVKU2BozfSUejVNhahAzZeyyDwhYJmhBaZi/3eOOlqGXj9UdkOXbl3vcwBH8wD30O9/4F5ERLKxzOaMnKZ+RpnygWF0qFhf+UeFMy+O06sdgiaFnXaSCsIy/SohspkKiLjNnhvrDNmPLMQbQKQlJdcp6zUzI7Gzys7luEmOxyMpA32lDBQcjL7KNwM15s4ytfrJ46XEPZUXESce2gj6NazcPPsrTa/Q2+oLS9GWupGh7AgMBAAE=";
 

--- a/backend/api/tests/handlers/step-functions/update-service.test.ts
+++ b/backend/api/tests/handlers/step-functions/update-service.test.ts
@@ -1,21 +1,30 @@
+const validateAuthorisationHeaderMock = jest.fn();
+
+jest.mock("../../../src/handlers/helper/validate-authorisation-header", () => ({
+    validateAuthorisationHeader: validateAuthorisationHeaderMock
+}));
+
 import {SFNClient, StartSyncExecutionCommand, SyncExecutionStatus} from "@aws-sdk/client-sfn";
 import {mockClient} from "aws-sdk-client-mock";
 import {constructTestApiGatewayEvent, mockLambdaContext} from "../utils";
-import {doUpdateServiceHandler} from "../../../src/handlers/step-functions/update-service";
-import {TEST_SERVICE_ID, TEST_SERVICE_NAME, TEST_USER_EMAIL} from "../constants";
+import {doUpdateServiceHandler, UpdateServiceBody} from "../../../src/handlers/step-functions/update-service";
+import {TEST_CLIENT_ID, TEST_SELF_SERVICE_CLIENT_ID, TEST_SERVICE_ID, TEST_USER_EMAIL, TEST_USER_ID} from "../constants";
 import {TEST_STATE_MACHINE_ARN} from "../../setup";
 import "aws-sdk-client-mock-jest";
 
-const TEST_UPDATE_SERVICE = {
-    service: {
-        serviceName: TEST_SERVICE_NAME,
-        id: TEST_SERVICE_ID
-    },
+import DynamoDbClient from "../../../src/dynamodb-client";
+
+const checkServiceUserExistsSpy = jest.spyOn(DynamoDbClient.prototype, "checkServiceUserExists");
+
+const TEST_UPDATE_SERVICE: UpdateServiceBody = {
+    serviceId: TEST_SERVICE_ID,
+    selfServiceClientId: TEST_SELF_SERVICE_CLIENT_ID,
+    clientId: TEST_CLIENT_ID,
     updates: {
         contactEmail: TEST_USER_EMAIL
     }
 };
-const TEST_NEW_CLIENT_EVENT = constructTestApiGatewayEvent({
+const TEST_UPDATE_CLIENT_EVENT = constructTestApiGatewayEvent({
     body: JSON.stringify(TEST_UPDATE_SERVICE),
     pathParameters: {}
 });
@@ -24,6 +33,12 @@ const mockSfnClient = mockClient(SFNClient);
 describe("newClientHandler tests", () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        mockSfnClient.reset();
+        validateAuthorisationHeaderMock.mockReturnValue({
+            valid: true,
+            userId: TEST_USER_ID
+        });
+        checkServiceUserExistsSpy.mockResolvedValue(true);
     });
 
     it("returns a 200 for a successful state machine invoke", async () => {
@@ -34,7 +49,7 @@ describe("newClientHandler tests", () => {
         };
         mockSfnClient.on(StartSyncExecutionCommand).resolves(mockSfnResponse);
 
-        const newClientResponse = await doUpdateServiceHandler(TEST_NEW_CLIENT_EVENT, mockLambdaContext);
+        const newClientResponse = await doUpdateServiceHandler(TEST_UPDATE_CLIENT_EVENT, mockLambdaContext);
 
         expect(mockSfnClient).toHaveReceivedCommandWith(StartSyncExecutionCommand, {
             input: JSON.stringify(TEST_UPDATE_SERVICE),
@@ -54,7 +69,7 @@ describe("newClientHandler tests", () => {
             executionArn: TEST_STATE_MACHINE_ARN
         });
 
-        const newClientResponse = await doUpdateServiceHandler(TEST_NEW_CLIENT_EVENT, mockLambdaContext);
+        const newClientResponse = await doUpdateServiceHandler(TEST_UPDATE_CLIENT_EVENT, mockLambdaContext);
 
         expect(mockSfnClient).toHaveReceivedCommandWith(StartSyncExecutionCommand, {
             input: JSON.stringify(TEST_UPDATE_SERVICE),
@@ -79,7 +94,7 @@ describe("newClientHandler tests", () => {
             cause: stateMachineErrorCause
         });
 
-        const newClientResponse = await doUpdateServiceHandler(TEST_NEW_CLIENT_EVENT, mockLambdaContext);
+        const newClientResponse = await doUpdateServiceHandler(TEST_UPDATE_CLIENT_EVENT, mockLambdaContext);
 
         expect(mockSfnClient).toHaveReceivedCommandWith(StartSyncExecutionCommand, {
             input: JSON.stringify(TEST_UPDATE_SERVICE),
@@ -89,6 +104,72 @@ describe("newClientHandler tests", () => {
         expect(newClientResponse).toStrictEqual({
             statusCode: 400,
             body: "Function returned error: " + stateMachineError + ", cause: " + stateMachineErrorCause
+        });
+    });
+
+    it("returns a 400 when the body does not exist", async () => {
+        const updateClientEvent = constructTestApiGatewayEvent({
+            body: "",
+            pathParameters: {}
+        });
+
+        const updateClientResponse = await doUpdateServiceHandler(updateClientEvent, mockLambdaContext);
+
+        expect(updateClientResponse).toStrictEqual({
+            statusCode: 400,
+            body: "Invalid Request, missing body"
+        });
+    });
+
+    it("returns a 400 when a serviceId does not exist", async () => {
+        const updateClientEvent = constructTestApiGatewayEvent({
+            body: JSON.stringify({}),
+            pathParameters: {}
+        });
+
+        const updateClientResponse = await doUpdateServiceHandler(updateClientEvent, mockLambdaContext);
+
+        expect(updateClientResponse).toStrictEqual({
+            statusCode: 400,
+            body: "Invalid Request, missing service ID"
+        });
+    });
+
+    it("returns the validation response when the authorisation header is not valid", async () => {
+        validateAuthorisationHeaderMock.mockReturnValue({
+            valid: false,
+            errorResponse: {
+                statusCode: 400,
+                body: "Invalid access token"
+            }
+        });
+
+        const updateClientEvent = constructTestApiGatewayEvent({
+            body: JSON.stringify({serviceId: TEST_SERVICE_ID}),
+            pathParameters: {}
+        });
+
+        const updateClientResponse = await doUpdateServiceHandler(updateClientEvent, mockLambdaContext);
+
+        expect(updateClientResponse).toStrictEqual({
+            statusCode: 400,
+            body: "Invalid access token"
+        });
+    });
+
+    it("returns a 403 when the service-user does not exist", async () => {
+        checkServiceUserExistsSpy.mockResolvedValue(false);
+
+        const updateClientEvent = constructTestApiGatewayEvent({
+            body: JSON.stringify({serviceId: TEST_SERVICE_ID}),
+            pathParameters: {}
+        });
+
+        const updateClientResponse = await doUpdateServiceHandler(updateClientEvent, mockLambdaContext);
+
+        expect(updateClientResponse).toStrictEqual({
+            statusCode: 403,
+            body: "Forbidden"
         });
     });
 });

--- a/backend/api/tests/helper/validate-authorisation-header.test.ts
+++ b/backend/api/tests/helper/validate-authorisation-header.test.ts
@@ -1,0 +1,51 @@
+import {validateAuthorisationHeader} from "../../../api/src/handlers/helper/validate-authorisation-header";
+import {TEST_ACCESS_TOKEN, TEST_USER_ID} from "../handlers/constants";
+
+describe("validateAuthorisationHEader tests", () => {
+    it("returns a 401 for no access token", () => {
+        expect(validateAuthorisationHeader(undefined)).toStrictEqual({
+            valid: false,
+            errorResponse: {
+                statusCode: 401,
+                body: "Missing access token"
+            }
+        });
+    });
+
+    it("returns a 401 for access token that does not start with Bearer", () => {
+        expect(validateAuthorisationHeader("Invalid Token")).toStrictEqual({
+            valid: false,
+            errorResponse: {
+                statusCode: 401,
+                body: "Missing access token"
+            }
+        });
+    });
+
+    it("returns 400 for an invalid access token that is not a valid signed JWT", () => {
+        expect(validateAuthorisationHeader("Bearer Invalid")).toStrictEqual({
+            valid: false,
+            errorResponse: {
+                statusCode: 400,
+                body: "Invalid access token"
+            }
+        });
+    });
+
+    it("returns 400 if the subject claim is not a string", () => {
+        expect(validateAuthorisationHeader("Bearer " + Buffer.from(JSON.stringify({sub: 123456789})).toString("base64url"))).toStrictEqual({
+            valid: false,
+            errorResponse: {
+                statusCode: 400,
+                body: "Invalid access token"
+            }
+        });
+    });
+
+    it("returns userId from the subject claim when valid", () => {
+        expect(validateAuthorisationHeader("Bearer " + TEST_ACCESS_TOKEN)).toStrictEqual({
+            valid: true,
+            userId: TEST_USER_ID
+        });
+    });
+});


### PR DESCRIPTION
Add checks to updateService to allow access.

Replicating the service and user check in the ListClient to the updateService. As some forms dont call the ListClient this is another layer of protection in assuring the user has access to the client update.