### PR TITLE
ATO- 1063 basic auth secret

### DIFF
--- a/express/src/controllers/clients.ts
+++ b/express/src/controllers/clients.ts
@@ -94,6 +94,10 @@ export const showClient: RequestHandler = async (req, res) => {
             changeIdTokenSigningAlgorithm: `/services/${serviceId}/clients/${authClientId}/${selfServiceClientId}/change-id-token-signing-algorithm?algorithm=${encodeURIComponent(
                 idTokenSigningAlgorithm
             )}`
+        },
+        basicAuthCreds: {
+            username: process.env.BASIC_AUTH_USERNAME ?? "",
+            password: process.env.BASIC_AUTH_PASSWORD ?? ""
         }
     });
 

--- a/express/src/views/clients/client-details.njk
+++ b/express/src/views/clients/client-details.njk
@@ -426,8 +426,8 @@
     <h3 class="govuk-heading-s">Details to view the end user journey in integration</h3>
     <p class="govuk-body">During the integration process, you’ll be prompted to enter the following details to see the end user journey. This is so the public do not confuse it with the live journey.</p>
     <p class="govuk-body">
-      <span class="govuk-!-font-weight-bold">Username</span>: integration-user<br>
-      <span class="govuk-!-font-weight-bold">Password</span>: winter2021
+      <span class="govuk-!-font-weight-bold">Username</span>: {{basicAuthCreds.username}}<br>
+      <span class="govuk-!-font-weight-bold">Password</span>: {{basicAuthCreds.password}}
     </p>
   </div>
 

--- a/express/tests/constants.ts
+++ b/express/tests/constants.ts
@@ -247,3 +247,5 @@ export const TEST_PUBLIC_BETA_FORM_SUBMISSION = {
 };
 
 export const TEST_USER_ATTRIBUTES = ["phone", "email"];
+export const TEST_BASIC_AUTH_USERNAME = "4oxh6rwLNOPxRc_zK3SdY6X5mHHQhnW6V77PNJKowiA";
+export const TEST_BASIC_AUTH_PASSWORD = "uJojpxvIyBIDle1nHnI6Fk5czqcoICQlE4Nmj5s8Qgc";

--- a/express/tests/controllers/clients.test.ts
+++ b/express/tests/controllers/clients.test.ts
@@ -38,6 +38,8 @@ import {
     TEST_ACCESS_TOKEN,
     TEST_AUTHENTICATION_RESULT,
     TEST_BACK_CHANNEL_LOGOUT_URI,
+    TEST_BASIC_AUTH_PASSWORD,
+    TEST_BASIC_AUTH_USERNAME,
     TEST_CLAIM,
     TEST_CLAIMS,
     TEST_CLAIMS_OUT,
@@ -98,6 +100,8 @@ describe("showClient Controller tests", () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        process.env.BASIC_AUTH_USERNAME = TEST_BASIC_AUTH_USERNAME;
+        process.env.BASIC_AUTH_PASSWORD = TEST_BASIC_AUTH_PASSWORD;
     });
 
     it("calls render with the expected template and options from the first client returned from s4 listClients", async () => {
@@ -159,6 +163,10 @@ describe("showClient Controller tests", () => {
                     "/services/service#123/clients/ajedebd2343/456/change-id-token-signing-algorithm?algorithm=ES256",
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=${TEST_CLAIM}`,
                 changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`
+            },
+            basicAuthCreds: {
+                username: TEST_BASIC_AUTH_USERNAME,
+                password: TEST_BASIC_AUTH_PASSWORD
             }
         });
         expect(mockRequest.session.serviceName).toStrictEqual(TEST_CLIENT.serviceName);
@@ -223,6 +231,10 @@ describe("showClient Controller tests", () => {
                 changeIdVerificationEnabledUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/enter-identity-verification`,
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=`,
                 changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`
+            },
+            basicAuthCreds: {
+                username: TEST_BASIC_AUTH_USERNAME,
+                password: TEST_BASIC_AUTH_PASSWORD
             }
         });
         expect(mockRequest.session.serviceName).toStrictEqual(TEST_CLIENT.serviceName);
@@ -287,6 +299,10 @@ describe("showClient Controller tests", () => {
                 changeIdVerificationEnabledUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/enter-identity-verification`,
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=${TEST_CLIENT.claims}`,
                 changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`
+            },
+            basicAuthCreds: {
+                username: TEST_BASIC_AUTH_USERNAME,
+                password: TEST_BASIC_AUTH_PASSWORD
             }
         });
         expect(mockRequest.session.serviceName).toStrictEqual(TEST_CLIENT.serviceName);
@@ -352,6 +368,10 @@ describe("showClient Controller tests", () => {
                     "/services/service#123/clients/ajedebd2343/456/change-id-token-signing-algorithm?algorithm=ES256",
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=${TEST_CLAIM}`,
                 changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`
+            },
+            basicAuthCreds: {
+                username: TEST_BASIC_AUTH_USERNAME,
+                password: TEST_BASIC_AUTH_PASSWORD
             }
         });
         expect(mockRequest.session.serviceName).toStrictEqual(TEST_CLIENT.serviceName);
@@ -416,6 +436,10 @@ describe("showClient Controller tests", () => {
                     "/services/service#123/clients/ajedebd2343/456/change-id-token-signing-algorithm?algorithm=ES256",
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=${TEST_CLAIM}`,
                 changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`
+            },
+            basicAuthCreds: {
+                username: TEST_BASIC_AUTH_USERNAME,
+                password: TEST_BASIC_AUTH_PASSWORD
             }
         });
         expect(mockRequest.session.serviceName).toStrictEqual(TEST_CLIENT.serviceName);
@@ -482,6 +506,10 @@ describe("showClient Controller tests", () => {
                     "/services/service#123/clients/ajedebd2343/456/change-id-token-signing-algorithm?algorithm=ES256",
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=${TEST_CLAIM}`,
                 changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`
+            },
+            basicAuthCreds: {
+                username: TEST_BASIC_AUTH_USERNAME,
+                password: TEST_BASIC_AUTH_PASSWORD
             }
         });
         expect(mockRequest.session.serviceName).toStrictEqual(TEST_CLIENT.serviceName);
@@ -547,6 +575,10 @@ describe("showClient Controller tests", () => {
                     "/services/service#123/clients/ajedebd2343/456/change-id-token-signing-algorithm?algorithm=ES256",
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=`,
                 changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`
+            },
+            basicAuthCreds: {
+                username: TEST_BASIC_AUTH_USERNAME,
+                password: TEST_BASIC_AUTH_PASSWORD
             }
         });
         expect(mockRequest.session.serviceName).toStrictEqual(TEST_CLIENT.serviceName);

--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -221,6 +221,10 @@ Resources:
                 - IsProd
                 - !Ref AWS::NoValue
                 - "{{resolve:secretsmanager:/self-service/frontend/fixed-otp-credentials}}"
+            - Name: BASIC_AUTH_USERNAME
+              Value: "{{resolve:secretsmanager:/self-service/frontend/basic-auth-username}}"
+            - Name: BASIC_AUTH_PASSWORD
+              Value: "{{resolve:secretsmanager:/self-service/frontend/basic-auth-password}}"
 
           PortMappings:
             - ContainerPort: !Ref ContainerPort

--- a/ui-automation-tests/acceptance-features/clients/client-details.feature
+++ b/ui-automation-tests/acceptance-features/clients/client-details.feature
@@ -8,10 +8,6 @@ Feature: A page where users can view the details associated with a client
     Scenario: The user is able to see the value for the field Client ID
       Then they should see the value for the Client ID "P0_ZdXojEGDlaZEU8Q9Zlv-fo1s"
 
-    @ci @smoke
-    Scenario: The user wants to view the user name and password for end journey
-      Then they should see the text "Username: integration-user"
-      And they should see the text "Password: winter2021"
 
   Rule: The the hidden content and the links which open in a new tab, are available for the user to view
     @ci @smoke


### PR DESCRIPTION
## Changes
### `Added` for new features:
- Derives basic auth credentials from environment variables when generating static content
- These are stored in secrets manager and pulled in at deploy time in the task definition 
- Removes any hardcoded values from the tests and pulls these in from ssm when the test container is ran

### `Changed` for changes in existing functionality

### `Deprecated` for soon-to-be removed features

### `Removed` for now removed features:
- Removes basic auth credentials from hardcoded content  and tests

### `Fixed` for any bug fixes

### `Security` in case of vulnerabilities


## Notes:
Two secrets needs to be manually created in each environment before this is deployed