### PR TITLE
BAU: Prevent evil domain substrings

### DIFF
--- a/express/src/lib/validators/allowed-email-domains.ts
+++ b/express/src/lib/validators/allowed-email-domains.ts
@@ -6,7 +6,7 @@ const allowedEmailDomains = loadAllowedEmailDomains();
 export default async function hasAllowedDomain(emailAddress: string): Promise<boolean> {
     const domains = await allowedEmailDomains;
     const emailDomain = getEmailDomain(emailAddress);
-    return domains.some(domain => emailDomain.endsWith(domain));
+    return domains.some(domain => emailDomain === domain || emailDomain.endsWith("." + domain));
 }
 
 function getEmailDomain(email: string) {

--- a/express/tests/lib/validators/allowed-email-domains.test.ts
+++ b/express/tests/lib/validators/allowed-email-domains.test.ts
@@ -18,10 +18,6 @@ describe("Verify email domains", () => {
         it("Allow an email address ending with a domain on the allowed list", async () => {
             expect(await hasAllowedDomain(`email@top.level.${allowedDomain}`)).toBe(true);
         });
-
-        it("Allow an email address ending with a subdomain on the allowed list", async () => {
-            expect(await hasAllowedDomain(`email@top.level${allowedSubDomain}`)).toBe(true);
-        });
     });
 
     describe("Reject invalid domains", () => {
@@ -35,6 +31,10 @@ describe("Verify email domains", () => {
 
         it("Reject an email address not ending with a subdomain on the allowed list", async () => {
             expect(await hasAllowedDomain(`email@top.level.${allowedSubDomain}.subdomain`)).toBe(false);
+        });
+
+        it("Rejects an email address where the allowed domain is a substring but not a subdomain", async () => {
+            expect(await hasAllowedDomain(`email@evil.not${allowedSubDomain}`)).toBe(false);
         });
     });
 });

--- a/express/tests/lib/validators/email-validator.test.ts
+++ b/express/tests/lib/validators/email-validator.test.ts
@@ -2,7 +2,7 @@ import validateEmail from "../../../src/lib/validators/email-validator";
 
 jest.mock("fs/promises", () => {
     return {
-        readFile: jest.fn(() => `allowed.domain\n.gov.uk`)
+        readFile: jest.fn(() => `allowed.domain\ngov.uk`)
     };
 });
 


### PR DESCRIPTION
Previously, if slc.co.uk were on the allowlist notslc.co.uk would also be permitted

