### PR TITLE
BAU: Pin ubuntu in linting step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
 
   check-linting:
     name: Linting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
       - name: Check linting and formatting


### PR DESCRIPTION
Linting has stopped working since change from ubuntu-24.04 to ubuntu 22.04

# Onboarding Feature Deployment

> [!WARNING]
> Pull requests merged to `main` will be released to production, please ensure the checklist below is complete

Before any work can be merged to main in must meet the definition of done and be ready to deploy. While many of these tasks will be automated, the reviewers must take the responsibility of confirming the checklist below has been completed before this ticket can be merged.

## Checklist

-   [ ] this pull request meets the acceptance criteria of the ticket

-   [ ] this branch is up-to-date with the main branch

    `git fetch --all && git rebase origin/main`

-   [ ] these changes are backwards compatible (no breaking changes)

    -   all methods signatures and return values are the same
    -   any replaced methods are marked as `@deprecated`

-   [ ] tests have been written to cover any new or updated functionality

-   [ ] new configuration parameters have been deployed to all environments, see [configuration management](https://govukverify.atlassian.net/l/cp/N7q3Vh3r).

-   [ ] all external infrastructure dependencies have been updated in all environments

## Changes

[ _please list the changes this pull request is making_ ]

### `Added` for new features

### `Changed` for changes in existing functionality

### `Deprecated` for soon-to-be removed features

### `Removed` for now removed features

### `Fixed` for any bug fixes

### `Security` in case of vulnerabilities
