### PR TITLE
Ato 1239/upload to pact broker

### DIFF
--- a/.github/workflows/deploy-contract.yml
+++ b/.github/workflows/deploy-contract.yml
@@ -1,0 +1,60 @@
+#Contract test workflow for Typescript
+name: Run Consumer Contract Test
+
+env:
+  PACT_USER: ${{ secrets.PACT_USER }}
+  PACT_PASSWORD: ${{ secrets.PACT_PASSWORD }}
+  PACT_URL: ${{ secrets.PACT_URL }}
+  PACT_BROKER_SOURCE_SECRET_DEV: ${{ secrets.PACT_BROKER_SOURCE_SECRET }}
+  GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
+  CONSUMER_APP_VERSION: ${{ github.sha }}
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+
+permissions:
+  id-token: write
+  contents: read
+
+
+jobs:
+  contract-testing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Install Tyepscript
+        run: npm install -D typescript
+
+      - name: Install Node
+        run: sudo apt install nodejs
+
+      - name: Install Pact Node
+        run: npm install @pact-foundation/pact-node --save
+
+      - name: Install dependencies
+        working-directory: ./backend/api/tests/contract-tests
+        run: npm install
+
+      - name: Build
+        working-directory: ./backend/api/tests/contract-tests
+        run: npm run buildts
+
+      - name: Run Pact Test
+        working-directory: ./backend/api/tests/contract-tests
+        run: npm run test:pact
+
+      - name: Publish Pact Contract
+        working-directory: ./backend/api/tests/contract-tests
+        if: github.actor != 'dependabot[bot]' && github.event_name == 'push'
+        run: |
+          npm run connect
+          npm run publish

--- a/backend/api/tests/contract-tests/package.json
+++ b/backend/api/tests/contract-tests/package.json
@@ -7,7 +7,8 @@
     "buildts": "tsc $(${CI:-false} && echo --sourceMap false)",
     "buildjs": "cp -r assets/javascripts dist/assets/",
     "build": "npm run buildts && npm run buildjs",
-    "publish": "node dist/publish.js",
+    "connect": "node dist/connect.js",
+    "publish": "node dist/publish.js",  
     "test": "jest && npm run publish",
     "test:pact": "jest --detectOpenHandles -runInBand"
   },

--- a/backend/api/tests/contract-tests/package.json
+++ b/backend/api/tests/contract-tests/package.json
@@ -7,7 +7,7 @@
     "buildts": "tsc $(${CI:-false} && echo --sourceMap false)",
     "buildjs": "cp -r assets/javascripts dist/assets/",
     "build": "npm run buildts && npm run buildjs",
-    "publish": "node dist/provider/publish.js",
+    "publish": "node dist/publish.js",
     "test": "jest && npm run publish",
     "test:pact": "jest --detectOpenHandles -runInBand"
   },

--- a/backend/api/tests/contract-tests/src/connect.ts
+++ b/backend/api/tests/contract-tests/src/connect.ts
@@ -1,0 +1,28 @@
+connectToPactBroker(
+    process.env.PACT_URL + "?testSource=" + process.env.PACT_BROKER_SOURCE_SECRET_DEV,
+    process.env.PACT_USER as string,
+    process.env.PACT_PASSWORD as string
+);
+
+//required to connect to PactBroker as Pact libraries don't allow testSource parameter to be passed
+function connectToPactBroker(pact_url: string, pact_user: string, pact_password: string): string {
+    const auth = btoa(`${pact_user}:${pact_password}`);
+
+    fetch(pact_url, {
+        headers: {
+            Authorization: `Basic ${auth}`
+        }
+    })
+        .then(function (response) {
+            if (response.ok) {
+                console.log("PACT BROKER AUTHORIZED SUCCESSFULLY VIA PROVIDER");
+                return response.status;
+            }
+            console.log("ERROR AUTHORIZING PACT BROKER");
+            throw response;
+        })
+        .catch(function (response) {
+            return response;
+        });
+    return "";
+}

--- a/backend/api/tests/contract-tests/src/publish.ts
+++ b/backend/api/tests/contract-tests/src/publish.ts
@@ -7,25 +7,22 @@ const {publishPacts} = pkg;
 
 import {resolve} from "path";
 
-const brokerUrl = process.env.PACT_BROKER_BASE_URL || "";
-const brokerUsername = process.env.PACT_BROKER_USERNAME || "";
-const brokerPassword = process.env.PACT_BROKER_PASSWORD || "";
+const brokerUrl = process.env.PACT_URL || "";
+const brokerUsername = process.env.PACT_USER || "";
+const brokerPassword = process.env.PACT_PASSWORD || "";
 
-const consumerVersion = "1.0.0";
-const providerVersion = "1.0.0";
+const consumerVersion = process.env.CONSUMER_APP_VERSION || "";
 
 const publishPact = async () => {
     try {
         const publishOptions = {
-            pactFilesOrDirs: ["src/pacts"],
+            pactFilesOrDirs: [resolve(process.cwd(), "pacts")],
             pactBroker: brokerUrl,
             pactBrokerUsername: brokerUsername,
             pactBrokerPassword: brokerPassword,
-            pactUrls: [resolve(process.cwd(), "src/pacts")],
-            logLevel: "debug",
+            logLevel: "info",
             consumerVersion: consumerVersion,
-            providerVersion: providerVersion,
-            providersVersionTags: ""
+            branch: process.env.GIT_BRANCH
         };
 
         const result = await publishPacts(publishOptions);

--- a/backend/api/tests/contract-tests/src/publish.ts
+++ b/backend/api/tests/contract-tests/src/publish.ts
@@ -36,8 +36,4 @@ const publishPact = async () => {
     }
 };
 
-if (process.arch.toString() != "x64") {
-    console.log("Unsupported architecture " + process.arch.toString() + " - bailing out.");
-} else {
-    void publishPact();
-}
+void publishPact();


### PR DESCRIPTION
# Onboarding Feature Deployment

Uploading the contract test to the pact broker. This has been tested uploading to the dev pact broker and also main. You can see on the Prod pact broker. 

Also added the needed secrets to this repo for the workflow to be able to connect and publish to the pact broker.
