### PR TITLE
ATO-1445: Adds rate limit to email otp codes

### DIFF
--- a/backend/api/api.template.yml
+++ b/backend/api/api.template.yml
@@ -1351,6 +1351,101 @@ Resources:
         - 'arn:aws:apigateway:${AWS::Region}::/restapis/${ResourceArn}/stages/${API.Stage}'
         - ResourceArn: !Ref API
 
+
+  ## Start Code Block Function ##
+
+  CodeBlockHandler:
+   # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Sourcemap: true
+        External:
+          - "@aws-sdk/*" # AWS SDK v3 dependencies are already included in the lambda runtime
+    Properties:
+      Handler: src/handlers/code-block/code-block-handler.handler
+      CodeSigningConfigArn: !If [ UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
+      Tracing: Active
+      Policies:
+        - AWSLambdaVPCAccessExecutionRole
+        - AWSXrayWriteOnlyAccess
+        - !Ref CodeRequestBlockTableCrudAccessPolicy
+        - !If [DynatraceLoggingEnabled, !Ref DynatraceSecretsAccessPolicy, !Ref "AWS::NoValue"]
+      Environment:
+        Variables:
+          CODE_BLOCK_TABLE_NAME:
+             Fn::ImportValue: 
+                !Sub ${DeploymentName}-CodeRequestBlockTableName
+      Events:
+        getCodeBlock:
+          Type: Api
+          Properties:
+            RestApiId: !Ref API
+            Path: /code-block/get/
+            Method: POST
+        putCodeBlock:
+          Type: Api
+          Properties:
+            RestApiId: !Ref API
+            Path: /code-block/put/
+            Method: POST
+        deleteCodeBlock:
+          Type: Api
+          Properties:
+            RestApiId: !Ref API
+            Path: /code-block/delete/
+            Method: POST
+
+  CodeRequestBlockTableCrudAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowCodeRequestBlockTableReadAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+            Resource: 
+              Fn::ImportValue: 
+                !Sub ${DeploymentName}-CodeRequestBlockTableArn
+          - Sid: AllowCodeRequestBlockTableDecryption
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource:
+              Fn::ImportValue: 
+                  !Sub ${DeploymentName}-CodeRequestBlockEncryptionKeyArn
+          - Sid: AllowCodeRequestBlockTableWriteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:PutItem
+              - dynamodb:UpdateItem
+            Resource: 
+              Fn::ImportValue: 
+                !Sub ${DeploymentName}-CodeRequestBlockTableArn
+          - Sid: AllowCodeRequestBlockTableEncryption
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+            Resource: 
+              Fn::ImportValue: 
+                  !Sub ${DeploymentName}-CodeRequestBlockEncryptionKeyArn
+          - Sid: CodeRequestBlockTableDeleteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DeleteItem
+            Resource:  
+              Fn::ImportValue: 
+                !Sub ${DeploymentName}-CodeRequestBlockTableArn
+
+  ## End Code Block Function ##
+
 Outputs:
   # SAM Serverless Function implicit API resources | Invoking private APIs
   # https://github.com/aws/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api

--- a/backend/api/src/handlers/code-block/code-block-handler.ts
+++ b/backend/api/src/handlers/code-block/code-block-handler.ts
@@ -1,0 +1,91 @@
+import {APIGatewayEvent, APIGatewayProxyResult, Context} from "aws-lambda";
+import {Logger} from "@aws-lambda-powertools/logger";
+import {deleteCodeBlock, getCodeBlock, putCodeBlock} from "../dynamodb/code-block-service";
+
+export const logger = new Logger({
+    serviceName: "self-service-experience"
+});
+
+export const handler = async (event: APIGatewayEvent, context: Context): Promise<APIGatewayProxyResult> => {
+    logger.addContext(context);
+
+    logger.info("Code block request received");
+
+    if (event.httpMethod !== "POST") {
+        logger.warn(`Invalid HTTP method: ${event.httpMethod}`);
+        return {
+            statusCode: 405,
+            body: `${event.httpMethod} not allowed`
+        };
+    }
+
+    if (!event.body) {
+        logger.warn("No request body in request");
+        return {
+            statusCode: 400,
+            body: "Invalid request"
+        };
+    }
+
+    let parsedBody;
+
+    try {
+        parsedBody = JSON.parse(event.body);
+    } catch (error) {
+        logger.warn("Invalid JSON in request body: " + (error as Error).message);
+        return {
+            statusCode: 400,
+            body: "Invalid request"
+        };
+    }
+
+    if (!isCodeBlockRequest(parsedBody)) {
+        logger.warn("Invalid Code block request");
+        return {
+            statusCode: 400,
+            body: "Invalid request"
+        };
+    }
+
+    switch (event.path) {
+        case "/code-block/get":
+            logger.info("Getting code block for identifier");
+            const isCodeBlockPresent = await getCodeBlock(parsedBody.id);
+            return {
+                statusCode: 200,
+                body: JSON.stringify({
+                    blocked: isCodeBlockPresent
+                })
+            };
+        case "/code-block/put":
+            logger.info("Putting code block for identifier");
+            await putCodeBlock(parsedBody.id);
+            return {
+                statusCode: 204,
+                body: ""
+            };
+
+        case "/code-block/delete":
+            logger.info("Removing code block for identifier");
+            await deleteCodeBlock(parsedBody.id);
+            return {
+                statusCode: 204,
+                body: ""
+            };
+        default:
+            logger.warn(`Invalid path; ${event.path}`);
+            return {
+                statusCode: 404,
+                body: "Not Found"
+            };
+    }
+};
+
+type CodeBlockRequest = {
+    id: string;
+};
+
+const isCodeBlockRequest = (arg: unknown): arg is CodeBlockRequest => {
+    const requestBody = arg as CodeBlockRequest;
+    return typeof requestBody === "object" && !Array.isArray(requestBody) && typeof requestBody.id === "string";
+};

--- a/backend/api/src/handlers/dynamodb/code-block-service.ts
+++ b/backend/api/src/handlers/dynamodb/code-block-service.ts
@@ -1,0 +1,56 @@
+import {DeleteItemCommand, DynamoDBClient, GetItemCommand, PutItemCommand} from "@aws-sdk/client-dynamodb";
+import {CodeBlockEntry} from "../types/code-block-entry";
+import {getEnvOrThrow} from "../helper/getEnv";
+import {Logger} from "@aws-lambda-powertools/logger";
+import {marshall, unmarshall} from "@aws-sdk/util-dynamodb";
+
+const dynamoClient = new DynamoDBClient();
+export const CODE_BLOCK_TTL = 60 * 60; // 1 Hour in seconds
+const nowInSeconds = () => Date.now() / 1000;
+//Dynamo TTL are in seconds
+const getTtl = () => nowInSeconds() + CODE_BLOCK_TTL;
+const logger = new Logger();
+
+export const getCodeBlock = async (codeBlockId: string): Promise<boolean> => {
+    logger.info("Getting code block entry");
+    const codeBlockEntry = await dynamoClient.send(
+        new GetItemCommand({
+            TableName: getEnvOrThrow("CODE_BLOCK_TABLE_NAME"),
+            Key: marshall({
+                CodeBlockIdentifier: codeBlockId
+            })
+        })
+    );
+
+    if (!codeBlockEntry.Item) {
+        return false;
+    }
+
+    return (unmarshall(codeBlockEntry.Item) as CodeBlockEntry).ttl > Date.now() / 1000;
+};
+
+export const putCodeBlock = async (codeBlockId: string): Promise<void> => {
+    logger.info("Putting code block entry");
+
+    await dynamoClient.send(
+        new PutItemCommand({
+            TableName: getEnvOrThrow("CODE_BLOCK_TABLE_NAME"),
+            Item: marshall({CodeBlockIdentifier: codeBlockId, ttl: getTtl()})
+        })
+    );
+    return;
+};
+
+export const deleteCodeBlock = async (codeBlockId: string): Promise<void> => {
+    logger.info("Removing code block entry");
+    await dynamoClient.send(
+        new DeleteItemCommand({
+            TableName: getEnvOrThrow("CODE_BLOCK_TABLE_NAME"),
+            Key: marshall({
+                CodeBlockIdentifier: codeBlockId
+            })
+        })
+    );
+
+    return;
+};

--- a/backend/api/src/handlers/helper/getEnv.ts
+++ b/backend/api/src/handlers/helper/getEnv.ts
@@ -1,0 +1,11 @@
+import {EnvironmentVariable} from "../types/handler-env-var";
+
+export const getEnvOrThrow = (name: EnvironmentVariable): string => {
+    const envVar = process.env[name];
+
+    if (!envVar) {
+        throw new Error("Missing Environment Variable: " + name);
+    }
+
+    return envVar;
+};

--- a/backend/api/src/handlers/types/code-block-entry.ts
+++ b/backend/api/src/handlers/types/code-block-entry.ts
@@ -1,0 +1,4 @@
+export type CodeBlockEntry = {
+    CodeBlockIdentifier: string; //PK
+    ttl: number;
+};

--- a/backend/api/src/handlers/types/handler-env-var.ts
+++ b/backend/api/src/handlers/types/handler-env-var.ts
@@ -1,0 +1,1 @@
+export type EnvironmentVariable = "CODE_BLOCK_TABLE_NAME";

--- a/backend/api/tests/handlers/code-block/code-block-handler.test.ts
+++ b/backend/api/tests/handlers/code-block/code-block-handler.test.ts
@@ -1,0 +1,155 @@
+const getCodeBlockMock = jest.fn();
+const putCodeBlockMock = jest.fn();
+const deleteCodeBlockMock = jest.fn();
+
+jest.mock("../../../src/handlers/dynamodb/code-block-service", () => ({
+    getCodeBlock: getCodeBlockMock,
+    putCodeBlock: putCodeBlockMock,
+    deleteCodeBlock: deleteCodeBlockMock
+}));
+
+import {constructTestApiGatewayEvent, mockLambdaContext} from "../utils";
+import {handler} from "../../../src/handlers/code-block/code-block-handler";
+
+describe("Code Block handler tests", () => {
+    it("rejects non post requests", async () => {
+        const event = {...constructTestApiGatewayEvent(), httpMethod: "GET"};
+
+        const response = await handler(event, mockLambdaContext);
+
+        expect(response).toStrictEqual({
+            statusCode: 405,
+            body: "GET not allowed"
+        });
+    });
+
+    it("rejects no event body", async () => {
+        const event = {...constructTestApiGatewayEvent(), httpMethod: "POST", body: null};
+
+        const response = await handler(event, mockLambdaContext);
+
+        expect(response).toStrictEqual({
+            statusCode: 400,
+            body: "Invalid request"
+        });
+    });
+
+    it("rejects invalid JSON", async () => {
+        const event = {...constructTestApiGatewayEvent(), httpMethod: "POST", body: "NotJson"};
+
+        const response = await handler(event, mockLambdaContext);
+
+        expect(response).toStrictEqual({
+            statusCode: 400,
+            body: "Invalid request"
+        });
+    });
+
+    it("rejects invalid code request bodies", async () => {
+        const event = {...constructTestApiGatewayEvent(), httpMethod: "POST", body: "{}"};
+
+        const response = await handler(event, mockLambdaContext);
+
+        expect(response).toStrictEqual({
+            statusCode: 400,
+            body: "Invalid request"
+        });
+    });
+
+    it("gets if the path is /code-block/get", async () => {
+        const codeBlockId = "email:code:block:1234";
+
+        getCodeBlockMock.mockResolvedValue(true);
+
+        const event = {
+            ...constructTestApiGatewayEvent(),
+            httpMethod: "POST",
+            body: JSON.stringify({
+                id: codeBlockId
+            }),
+            path: "/code-block/get"
+        };
+
+        const response = await handler(event, mockLambdaContext);
+
+        expect(getCodeBlockMock).toHaveBeenCalledWith(codeBlockId);
+        expect(response).toStrictEqual({
+            statusCode: 200,
+            body: JSON.stringify({
+                blocked: true
+            })
+        });
+    });
+
+    it("puts if the path is /code-block/put", async () => {
+        const codeBlockId = "email:code:block:1234";
+
+        putCodeBlockMock.mockResolvedValue(void 0);
+
+        const event = {
+            ...constructTestApiGatewayEvent(),
+            httpMethod: "POST",
+            body: JSON.stringify({
+                id: codeBlockId
+            }),
+            path: "/code-block/put"
+        };
+
+        const response = await handler(event, mockLambdaContext);
+
+        expect(putCodeBlockMock).toHaveBeenCalledWith(codeBlockId);
+        expect(response).toStrictEqual({
+            statusCode: 204,
+            body: ""
+        });
+    });
+
+    it("deletes if the path is /code-block/delete", async () => {
+        const codeBlockId = "email:code:block:1234";
+
+        deleteCodeBlockMock.mockResolvedValue(void 0);
+
+        const event = {
+            ...constructTestApiGatewayEvent(),
+            httpMethod: "POST",
+            body: JSON.stringify({
+                id: codeBlockId
+            }),
+            path: "/code-block/delete"
+        };
+
+        const response = await handler(event, mockLambdaContext);
+
+        expect(deleteCodeBlockMock).toHaveBeenCalledWith(codeBlockId);
+        expect(response).toStrictEqual({
+            statusCode: 204,
+            body: ""
+        });
+    });
+
+    it("returns a 404 for unknown path", async () => {
+        const codeBlockId = "email:code:block:1234";
+
+        deleteCodeBlockMock.mockResolvedValue(void 0);
+
+        const event = {
+            ...constructTestApiGatewayEvent(),
+            httpMethod: "POST",
+            body: JSON.stringify({
+                id: codeBlockId
+            }),
+            path: "/code-block/notValid"
+        };
+
+        const response = await handler(event, mockLambdaContext);
+
+        expect(getCodeBlockMock).not.toHaveBeenCalled();
+        expect(putCodeBlockMock).not.toHaveBeenCalled();
+        expect(deleteCodeBlockMock).not.toHaveBeenCalled();
+
+        expect(response).toStrictEqual({
+            statusCode: 404,
+            body: "Not Found"
+        });
+    });
+});

--- a/backend/api/tests/handlers/service/code-block-service.test.ts
+++ b/backend/api/tests/handlers/service/code-block-service.test.ts
@@ -1,0 +1,89 @@
+import {mockClient} from "aws-sdk-client-mock";
+import "aws-sdk-client-mock-jest";
+import {CODE_BLOCK_TTL, deleteCodeBlock, getCodeBlock, putCodeBlock} from "../../../src/handlers/dynamodb/code-block-service";
+import {DeleteItemCommand, DynamoDBClient, GetItemCommand, PutItemCommand} from "@aws-sdk/client-dynamodb";
+import {marshall} from "@aws-sdk/util-dynamodb";
+
+const mockDynamoClient = mockClient(DynamoDBClient);
+
+describe("code block service tests", () => {
+    const TEST_TIMESTAMP = 1740577617;
+    const mockTableName = "mock-Code-Block-Table";
+
+    beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(TEST_TIMESTAMP);
+        process.env.CODE_BLOCK_TABLE_NAME = mockTableName;
+        mockDynamoClient.reset();
+    });
+
+    it("returns true for a code block entry with a TTL in the future", async () => {
+        const codeBlockId = "email:code:block:123456";
+        const validCodeBlock = {
+            CodeBlockIdentifier: codeBlockId,
+            ttl: TEST_TIMESTAMP / 1000 + 10000
+        };
+
+        mockDynamoClient
+            .on(GetItemCommand, {
+                Key: marshall({
+                    CodeBlockIdentifier: codeBlockId
+                })
+            })
+            .resolves({
+                Item: marshall(validCodeBlock)
+            });
+
+        const isCodeBlocked = await getCodeBlock(codeBlockId);
+
+        expect(isCodeBlocked).toBe(true);
+    });
+
+    it("returns false for a code block entry with a TTL in the past", async () => {
+        const codeBlockId = "email:code:block:123456";
+        const expiredCodeBlock = {
+            CodeBlockIdentifier: codeBlockId,
+            ttl: TEST_TIMESTAMP / 1000 - 10000
+        };
+
+        mockDynamoClient
+            .on(GetItemCommand, {
+                TableName: mockTableName,
+                Key: marshall({
+                    CodeBlockIdentifier: codeBlockId
+                })
+            })
+            .resolves({
+                Item: marshall(expiredCodeBlock)
+            });
+        const isCodeBlocked = await getCodeBlock(codeBlockId);
+
+        expect(isCodeBlocked).toBe(false);
+    });
+
+    it("puts a code block entry with expected identifier", async () => {
+        const codeBlockId = "email:code:block:123456";
+
+        await putCodeBlock(codeBlockId);
+
+        expect(mockDynamoClient).toHaveReceivedCommandWith(PutItemCommand, {
+            TableName: mockTableName,
+            Item: marshall({
+                CodeBlockIdentifier: codeBlockId,
+                ttl: TEST_TIMESTAMP / 1000 + CODE_BLOCK_TTL
+            })
+        });
+    });
+
+    it("deletes an existing code block", async () => {
+        const codeBlockId = "email:code:block:123456";
+
+        await deleteCodeBlock(codeBlockId);
+
+        expect(mockDynamoClient).toHaveReceivedCommandWith(DeleteItemCommand, {
+            TableName: mockTableName,
+            Key: marshall({
+                CodeBlockIdentifier: codeBlockId
+            })
+        });
+    });
+});

--- a/backend/dynamodb/dynamodb.template.yml
+++ b/backend/dynamodb/dynamodb.template.yml
@@ -71,6 +71,59 @@ Resources:
       SSESpecification:
         SSEEnabled: true
 
+
+    ## CodeRequestBlockTable ##
+
+  CodeRequestBlockEncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: KMS encryption key for CodeRequestBlock DynamoDB table
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowIamManagement
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: "*"
+          - Sid: AllowDynamodbAccessToEncryptionKey
+            Effect: Allow
+            Principal:
+              Service: dynamodb.amazonaws.com
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource: "*"
+            Condition:
+              ArnLike:
+                kms:EncryptionContext:aws:dynamodb:table/arn: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*
+
+  CodeRequestBlockTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub ${DeploymentName}-Code-Request-Block
+      AttributeDefinitions:
+        - AttributeName: CodeBlockIdentifier
+          AttributeType: S
+      KeySchema:
+        - AttributeName: CodeBlockIdentifier
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+      SSESpecification:
+        SSEEnabled: true
+        KMSMasterKeyId: !GetAtt CodeRequestBlockEncryptionKey.Arn
+        SSEType: KMS
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+
 Outputs:
   DataTableName:
     Value: !Ref DataTable
@@ -84,3 +137,16 @@ Outputs:
     Value: !GetAtt SessionsTable.Arn
     Export:
       Name: !Sub ${DeploymentName}-DynamoDB-SessionsTableARN
+  CodeRequestBlockTableName:
+    Value: !Ref CodeRequestBlockTable
+    Export:
+      Name: !Sub ${DeploymentName}-CodeRequestBlockTableName
+  CodeRequestBlockTableArn:
+    Value: !GetAtt CodeRequestBlockTable.Arn
+    Export:
+      Name: !Sub ${DeploymentName}-CodeRequestBlockTableArn
+  CodeRequestBlockTableKmsKeyArn:
+    Value: !GetAtt CodeRequestBlockEncryptionKey.Arn
+    Export:
+      Name: !Sub ${DeploymentName}-CodeRequestBlockEncryptionKeyArn
+

--- a/express/package.json
+++ b/express/package.json
@@ -19,9 +19,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3.625.0",
-    "@aws-sdk/client-dynamodb": "^3.632.0",
     "@aws-sdk/util-dynamodb": "^3.624.0",
-    "@aws-sdk/client-sqs": "^3.609.0",
     "axios": "^1.7.4",
     "connect-dynamodb": "^3.0.0",
     "express": "^4.21.2",

--- a/express/src/controllers/register.ts
+++ b/express/src/controllers/register.ts
@@ -333,15 +333,35 @@ export const submitMobileVerificationCode: RequestHandler = async (req, res) => 
 };
 
 export const showResendPhoneCodeForm = render("register/resend-text-code.njk");
-export const showResendEmailCodeForm = render("register/resend-email-code.njk");
+export const showResendEmailCodeForm: RequestHandler = async (req, res) => {
+    const s4: SelfServiceServicesService = await req.app.get("backing-service");
+
+    if (
+        (req.session.emailCodeSubmitCount && req.session.emailCodeSubmitCount >= 6) ||
+        (await s4.getEmailCodeBlock((req.session.emailAddress as string).toLowerCase().trim()))
+    ) {
+        res.render("/register/too-many-codes.njk");
+        return;
+    }
+
+    res.render("register/resend-email-code.njk");
+};
 export const resumeAfterPassword = render("register/resume-after-password.njk");
 
 export const resendEmailVerificationCode: RequestHandler = async (req, res) => {
     const s4: SelfServiceServicesService = await req.app.get("backing-service");
 
     console.info("Resending E-Mail Verification Code");
+    if (
+        (req.session.emailCodeSubmitCount && req.session.emailCodeSubmitCount >= 6) ||
+        (await s4.getEmailCodeBlock((req.session.emailAddress as string).toLowerCase().trim()))
+    ) {
+        res.render("/register/too-many-codes.njk");
+        return;
+    }
+
     await s4.resendEmailAuthCode(req.session.emailAddress as string);
-    res.redirect("/register/enter-email-code");
+    return res.redirect("/register/enter-email-code");
 };
 
 export const showAddServiceForm = render("register/add-service-name.njk");

--- a/express/src/services/lambda-facade/LambdaFacadeInterface.ts
+++ b/express/src/services/lambda-facade/LambdaFacadeInterface.ts
@@ -51,4 +51,7 @@ export default interface LambdaFacadeInterface {
 
     deleteClientEntries(oldUserID: string, serviceID: string, accessToken: string): Promise<void>;
     deleteServiceEntries(serviceID: string, accessToken: string): Promise<void>;
+    getEmailCodeBlock(email: string): Promise<boolean>;
+    putEmailCodeBlock(email: string): Promise<void>;
+    removeEmailCodeBlock(email: string): Promise<void>;
 }

--- a/express/src/services/lambda-facade/StubLambdaFacade.ts
+++ b/express/src/services/lambda-facade/StubLambdaFacade.ts
@@ -218,4 +218,19 @@ export default class StubLambdaFacade implements LambdaFacadeInterface {
         console.log(JSON.stringify(message));
         return;
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async getEmailCodeBlock(_email: string): Promise<boolean> {
+        return false;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async putEmailCodeBlock(_e: string): Promise<void> {
+        return;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async removeEmailCodeBlock(_e: string): Promise<void> {
+        return;
+    }
 }

--- a/express/src/services/self-service-services-service.ts
+++ b/express/src/services/self-service-services-service.ts
@@ -401,4 +401,16 @@ export default class SelfServiceServicesService {
         await this.validateToken(accessToken, "deleteServiceEntries");
         await this.lambda.deleteServiceEntries(serviceID, accessToken);
     }
+
+    async getEmailCodeBlock(email: string): Promise<boolean> {
+        return this.lambda.getEmailCodeBlock(email);
+    }
+
+    async putEmailCodeBlock(email: string): Promise<void> {
+        await this.lambda.putEmailCodeBlock(email);
+    }
+
+    async removeEmailCodeBlock(email: string): Promise<void> {
+        await this.lambda.removeEmailCodeBlock(email);
+    }
 }

--- a/express/src/types/code-block-response.ts
+++ b/express/src/types/code-block-response.ts
@@ -1,0 +1,3 @@
+export type CodeBlockResponse = {
+    blocked: boolean;
+};

--- a/express/src/types/session-data.d.ts
+++ b/express/src/types/session-data.d.ts
@@ -11,4 +11,5 @@ export default interface SelfServiceSessionData extends Record<string, unknown> 
     mfaResponse: MfaResponse;
     updatedField: string;
     serviceName: string;
+    emailCodeSubmitCount: number;
 }

--- a/express/src/views/register/too-many-codes.njk
+++ b/express/src/views/register/too-many-codes.njk
@@ -1,0 +1,12 @@
+{% extends "layouts/base.njk" %}
+
+{% set pageTitle = "You've entered too many security codes" %}
+
+{% block mainContent %}
+  <h1 class="govuk-heading-l">You've entered the wrong security code too many times</h1>
+   <h3 class="govuk-heading-m">What you can do</h3>
+  <p class="govuk-body">Wait 1 hour and return to the GOV.UK One Login admin tool. If you need help urgently, contact us through our
+    <a class="govuk-link" href="https://www.sign-in.service.gov.uk/contact-us?adminTool">support form</a> or
+    <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC">Slack channel</a>.
+  </p>
+{% endblock %}

--- a/express/tests/mocks.ts
+++ b/express/tests/mocks.ts
@@ -16,7 +16,10 @@ export const mockLambdaFacade = {
     listClients: jest.fn(),
     updateClient: jest.fn(),
     updateService: jest.fn(),
-    sessionCount: jest.fn()
+    sessionCount: jest.fn(),
+    getEmailCodeBlock: jest.fn(),
+    putEmailCodeBlock: jest.fn(),
+    removeEmailCodeBlock: jest.fn()
 };
 
 export const mockCognitoInterface = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.609.0",
         "@aws-sdk/client-sqs": "^3.609.0",
-        "@aws-sdk/util-dynamodb": "^3.624.0",
         "@pact-foundation/pact": "^13.1.5",
         "axios": "^1.7.4",
         "googleapis": "^128.0.0",
@@ -113,8 +112,6 @@
       "name": "gds-di-self-service-frontend",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.625.0",
-        "@aws-sdk/client-dynamodb": "^3.632.0",
-        "@aws-sdk/client-sqs": "^3.609.0",
         "@aws-sdk/util-dynamodb": "^3.624.0",
         "axios": "^1.7.4",
         "connect-dynamodb": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.609.0",
     "@aws-sdk/client-sqs": "^3.609.0",
-    "@aws-sdk/util-dynamodb": "^3.624.0",
     "@pact-foundation/pact": "^13.1.5",
     "axios": "^1.7.4",
     "googleapis": "^128.0.0",

--- a/ui-automation-tests/acceptance-features/register.feature
+++ b/ui-automation-tests/acceptance-features/register.feature
@@ -100,6 +100,24 @@ Feature: Users can sign up to the self-service experience
         |        | Enter the 6 digit security code                                                           |
         | 000000 | The code you entered is not correct or has expired - enter it again or request a new code |
 
+  Rule: The user is locked out when submitting 6 incorrect code attempts
+    Background:
+      When they submit an incorrect security code "000000"
+      Then the error message "The code you entered is not correct or has expired - enter it again or request a new code" must be displayed for the security code field
+      When they submit an incorrect security code "000000"
+      Then the error message "The code you entered is not correct or has expired - enter it again or request a new code" must be displayed for the security code field
+      When they submit an incorrect security code "000000"
+      Then the error message "The code you entered is not correct or has expired - enter it again or request a new code" must be displayed for the security code field
+      When they submit an incorrect security code "000000"
+      Then the error message "The code you entered is not correct or has expired - enter it again or request a new code" must be displayed for the security code field
+      When they submit an incorrect security code "000000"
+      Then the error message "The code you entered is not correct or has expired - enter it again or request a new code" must be displayed for the security code field
+      When they submit an incorrect security code "000000"
+      Then the error message "The code you entered is not correct or has expired - enter it again or request a new code" must be displayed for the security code field
+      When they submit an incorrect security code "000000"
+       Then they should be redirected to a page with the title "You've entered too many security codes"
+
+
   Rule: The user does not receive their email security code and clicks 'Not received an email?' link
     Background:
       Given they submit a random valid email address


### PR DESCRIPTION
### Wider context of change
When registering with the SSE tool, you receive an email OTP code. There was previously no rate limit on submitting these, so it was plausible to enumerate through all possible values.

 This PR adds two safeguards to this:
- A session side check in which a count is incremented every time a  incorrect code is submitted
- A backend check where the hashed email is stored against a 1 hour ttl. This is triggered when the user submits 6 incorrect OTP codes.

### What’s changed:

- Introduced a session side check for emailCode request count which is incremented when an incorrect code is submitted
- Introduces a new dynamo table backend lambda for code request blocking. This has been left fairly generic so it could be potentially applied to other things in the future. This table will store the hashed email with a prefix and a ttl of one hour.
- Implements session side and backend checking for code blocks when a user submits an OTP code or tries to navigate to the resend email code page

### Manual testing:
- Deployed to dev currently: https://admin.development.sign-in.service.gov.uk/
- Try to sign up for an account: https://admin.development.sign-in.service.gov.uk/register/enter-email-address
- Get to email OTP page
- Enter incorrect code 6 times
- See the "You've entered the wrong security code too many times" page 
- Clear cookies 
- Resubmit same email 
- See the same page

- Any combination of these/whatever you can think of to get around this


## Checklist

-   [x] this pull request meets the acceptance criteria of the ticket

-   [x] this branch is up-to-date with the main branch

    `git fetch --all && git rebase origin/main`

-   [x] these changes are backwards compatible (no breaking changes)

    -   all methods signatures and return values are the same
    -   any replaced methods are marked as `@deprecated`

-   [x] tests have been written to cover any new or updated functionality

-   [x] new configuration parameters have been deployed to all environments, see [configuration management](https://govukverify.atlassian.net/l/cp/N7q3Vh3r).

-   [x] all external infrastructure dependencies have been updated in all environments
