### PR TITLE
ATO-1483: upgrade node runtime from 18 to 22

### DIFF
--- a/backend/api/api.template.yml
+++ b/backend/api/api.template.yml
@@ -107,7 +107,7 @@ Conditions:
 Globals:
   Function:
     Timeout: 15
-    Runtime: nodejs18.x
+    Runtime: nodejs22.x
     PermissionsBoundary: !If [ UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
     VpcConfig:
       SecurityGroupIds: [ !ImportValue VPC-VPCEndpointsSecurityGroup ]

--- a/backend/api/package.json
+++ b/backend/api/package.json
@@ -16,7 +16,7 @@
     "@aws-sdk/client-dynamodb": "^3.609.0",
     "@aws-sdk/util-dynamodb": "^3.624.0",
     "@aws-lambda-powertools/logger": "2.6.0",
-    "axios": "^1.7.4",
+    "axios": "^1.8.2",
     "esbuild": "^0.25.0",
     "sinon": "^17.0.1"
   },

--- a/backend/cognito/cognito.template.yml
+++ b/backend/cognito/cognito.template.yml
@@ -108,7 +108,7 @@ Conditions:
 Globals:
   Function:
     Timeout: 10
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
     PermissionsBoundary: !If [ UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
     VpcConfig:
       SecurityGroupIds: [ !ImportValue VPC-VPCEndpointsSecurityGroup ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@aws-sdk/client-dynamodb": "^3.609.0",
         "@aws-sdk/client-sqs": "^3.609.0",
         "@pact-foundation/pact": "^13.1.5",
-        "axios": "^1.7.4",
+        "axios": "^1.8.2",
         "googleapis": "^128.0.0",
         "googleapis-common": "^7.2.0",
         "helmet": "^7.0.0"
@@ -47,7 +47,7 @@
         "@aws-sdk/client-sns": "^3.609.0",
         "@aws-sdk/client-sqs": "^3.609.0",
         "@aws-sdk/util-dynamodb": "^3.624.0",
-        "axios": "^1.7.4",
+        "axios": "^1.8.2",
         "esbuild": "^0.25.0",
         "sinon": "^17.0.1"
       },
@@ -4308,9 +4308,10 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@aws-sdk/client-dynamodb": "^3.609.0",
     "@aws-sdk/client-sqs": "^3.609.0",
     "@pact-foundation/pact": "^13.1.5",
-    "axios": "^1.7.4",
+    "axios": "^1.8.2",
     "googleapis": "^128.0.0",
     "googleapis-common": "^7.2.0",
     "helmet": "^7.0.0"


### PR DESCRIPTION
# Onboarding Feature Deployment

- Tested on the dev environment, ran through the following journey's successfully:
  - _API version bump:_
    - Full sign up journey
    - Full sign in journey
  - _Cognito lambda version bump:_
    - SMS OTP sending (tests `SendSecurityCodeTextMessageFunction`)
    - Full password change journey (request reset, perform reset)
      - Tests `CreatePasswordResetMessageFunction`
      - Tests `SendPasswordChangedEmailFunction` (note that no email was received as this functionality [has been disabled](https://github.com/govuk-one-login/onboarding-self-service-experience/commit/3e08b97dbf5a694f8292decbfb3968fa9728467d), the lambda or wider system did not experience any errors though).
- Acceptance tests (fairly comprehensive) passing.

> [!WARNING]
> Pull requests merged to `main` will be released to production, please ensure the checklist below is complete

Before any work can be merged to main in must meet the definition of done and be ready to deploy. While many of these tasks will be automated, the reviewers must take the responsibility of confirming the checklist below has been completed before this ticket can be merged.

## Checklist

-   [x] this pull request meets the acceptance criteria of the ticket

-   [x] this branch is up-to-date with the main branch

    `git fetch --all && git rebase origin/main`

-   [x] these changes are backwards compatible (no breaking changes)

    -   all methods signatures and return values are the same
    -   any replaced methods are marked as `@deprecated`

-   [ ] tests have been written to cover any new or updated functionality - **n/a**

-   [ ] new configuration parameters have been deployed to all environments, see [configuration management](https://govukverify.atlassian.net/l/cp/N7q3Vh3r) - **n/a**

-   [ ] all external infrastructure dependencies have been updated in all environments - **n/a**

## Changes

### `Added` for new features

### `Changed` for changes in existing functionality

- Bumped API node runtime version from 18 to 22
- Bumped Cognito node runtime version from 18 to 22
- Bumped axios version to the latest stable version
  - This was marked as a `high severity vulnerability` and was causing the vulnerability check job to fail

### `Deprecated` for soon-to-be removed features

### `Removed` for now removed features

### `Fixed` for any bug fixes

### `Security` in case of vulnerabilities
