### PR TITLE
Ato 1493 add pkce enforced client registry

### DIFF
--- a/backend/api/src/handlers/dynamodb/put-service-client.ts
+++ b/backend/api/src/handlers/dynamodb/put-service-client.ts
@@ -50,6 +50,7 @@ export const putServiceClientHandler = async (event: handlerInvokeEvent): Promis
         client_name: "integration",
         service_name: payload.service.serviceName,
         identity_verification_supported: false,
+        pkce_enforced: false,
         claims: [],
         back_channel_logout_uri: payload.back_channel_logout_uri,
         sector_identifier_uri: payload.sector_identifier_uri,
@@ -71,7 +72,8 @@ export const putServiceClientHandler = async (event: handlerInvokeEvent): Promis
             "back_channel_logout_uri",
             "token_endpoint_auth_method",
             "id_token_signing_algorithm",
-            "max_age_enabled"
+            "max_age_enabled",
+            "pkce_enforced"
         ]
     };
 

--- a/backend/api/tests/handlers/dynamodb/put-service-client.test.ts
+++ b/backend/api/tests/handlers/dynamodb/put-service-client.test.ts
@@ -24,6 +24,7 @@ const testRegistrationResponse = {
     response_type: "code",
     jar_validation_required: false,
     identity_verification_supported: false,
+    pkce_enforced: false,
     client_type: "web",
     service: {
         id: "service#1234Random",
@@ -49,6 +50,7 @@ const expectedDynamoRecord = {
     client_name: "integration",
     service_name: testRegistrationResponse.service.serviceName,
     identity_verification_supported: false,
+    pkce_enforced: false,
     claims: [],
     back_channel_logout_uri: testRegistrationResponse.back_channel_logout_uri,
     sector_identifier_uri: testRegistrationResponse.sector_identifier_uri,
@@ -70,7 +72,8 @@ const expectedDynamoRecord = {
         "back_channel_logout_uri",
         "token_endpoint_auth_method",
         "id_token_signing_algorithm",
-        "max_age_enabled"
+        "max_age_enabled",
+        "pkce_enforced"
     ]
 };
 

--- a/express/@types/client.d.ts
+++ b/express/@types/client.d.ts
@@ -24,6 +24,7 @@ export interface ClientFromDynamo {
     id_token_signing_algorithm?: "ES256" | "RS256";
     client_locs?: string[];
     max_age_enabled?: boolean;
+    pkce_enforced: boolean;
 }
 
 export interface Client {
@@ -52,4 +53,5 @@ export interface Client {
     id_token_signing_algorithm?: "ES256" | "RS256";
     client_locs?: string[];
     max_age_enabled?: boolean;
+    pkce_enforced: boolean;
 }

--- a/express/src/controllers/clients.ts
+++ b/express/src/controllers/clients.ts
@@ -949,3 +949,11 @@ export const processMaxAgeEnabledForm = async (req: Request, res: Response): Pro
     req.session.updatedField = "Max Age Enabled";
     res.redirect(`/services/${serviceId}/clients`);
 };
+
+export const showChangePKCEEnforcedForm: RequestHandler = (req: Request, res: Response): void => {
+    res.render("clients/change-pkce-enforced.njk", {
+        serviceId: req.context.serviceId,
+        selfServiceClientId: req.params.selfServiceClientId,
+        clientId: req.params.clientId
+    });
+};

--- a/express/src/controllers/clients.ts
+++ b/express/src/controllers/clients.ts
@@ -31,6 +31,7 @@ export const showClient: RequestHandler = async (req, res) => {
     const claims = identityVerificationSupported && client.claims ? client.claims : [];
     const idTokenSigningAlgorithm = client.id_token_signing_algorithm ?? "";
     const maxAgeEnabled = client.max_age_enabled;
+    const pkceEnforced = client.pkce_enforced;
 
     if (client.publicKeySource == "JWKS" && client.token_endpoint_auth_method != "client_secret_post") {
         displayedKey = client.jwksUri;
@@ -56,6 +57,7 @@ export const showClient: RequestHandler = async (req, res) => {
         contacts: contacts,
         token_endpoint_auth_method: client.token_endpoint_auth_method,
         identityVerificationSupported: identityVerificationSupported,
+        pkceEnforced: pkceEnforced,
         authMethod: client.token_endpoint_auth_method,
         ...(client.identity_verification_supported === true && {
             levelsOfConfidence: client.client_locs ? client.client_locs.join(" ") : ""

--- a/express/src/controllers/clients.ts
+++ b/express/src/controllers/clients.ts
@@ -98,7 +98,8 @@ export const showClient: RequestHandler = async (req, res) => {
             changeIdTokenSigningAlgorithm: `/services/${serviceId}/clients/${authClientId}/${selfServiceClientId}/change-id-token-signing-algorithm?algorithm=${encodeURIComponent(
                 idTokenSigningAlgorithm
             )}`,
-            changeMaxAgeEnabled: `/services/${serviceId}/clients/${authClientId}/${selfServiceClientId}/change-max-age-enabled`
+            changeMaxAgeEnabled: `/services/${serviceId}/clients/${authClientId}/${selfServiceClientId}/change-max-age-enabled`,
+            changePKCEEnforcedUri: `/services/${serviceId}/clients/${authClientId}/${selfServiceClientId}/change-pkce-enforced`
         },
         basicAuthCreds: {
             username: process.env.BASIC_AUTH_USERNAME ?? "",

--- a/express/src/lib/models/client-utils.ts
+++ b/express/src/lib/models/client-utils.ts
@@ -26,6 +26,7 @@ export function dynamoClientToDomainClient(client: ClientFromDynamo): Client {
         claims: client.claims,
         id_token_signing_algorithm: client.id_token_signing_algorithm,
         client_locs: client.client_locs,
-        max_age_enabled: client.max_age_enabled
+        max_age_enabled: client.max_age_enabled,
+        pkce_enforced: client.pkce_enforced
     };
 }

--- a/express/src/routes/clients.ts
+++ b/express/src/routes/clients.ts
@@ -38,7 +38,9 @@ import {
     showChangeIdTokenAlgorithmForm,
     processChangeIdTokenAlgorithmForm,
     showMaxAgeEnabledForm,
-    processMaxAgeEnabledForm
+    processMaxAgeEnabledForm,
+    showChangePKCEEnforcedForm,
+    processChangePKCEEnforcedForm
 } from "../controllers/clients";
 import validateKeySource from "../middleware/validate-public-key";
 import validateUri from "../middleware/validators/uri-validator";
@@ -130,3 +132,5 @@ router
     .post(processChangeIdTokenAlgorithmForm);
 
 router.route("/:clientId/:selfServiceClientId/change-max-age-enabled").get(showMaxAgeEnabledForm).post(processMaxAgeEnabledForm);
+
+router.route("/:clientId/:selfServiceClientId/change-pkce-enforced").get(showChangePKCEEnforcedForm).post(processChangePKCEEnforcedForm);

--- a/express/src/services/lambda-facade/StubLambdaFacade.ts
+++ b/express/src/services/lambda-facade/StubLambdaFacade.ts
@@ -24,6 +24,7 @@ export default class StubLambdaFacade implements LambdaFacadeInterface {
     private client_locs = ["P2"];
     private id_token_signing_algorithm = "ES256";
     private maxAgeEnabled = false;
+    private pkceEnforced = false;
 
     private user: DynamoUser = {
         last_name: {S: "we haven't collected this last name"},
@@ -112,6 +113,10 @@ export default class StubLambdaFacade implements LambdaFacadeInterface {
         if (typeof updates.max_age_enabled !== "undefined") {
             this.maxAgeEnabled = updates.max_age_enabled as boolean;
         }
+
+        if (typeof updates.pkce_enforced !== "undefined") {
+            this.pkceEnforced = updates.pkce_enforced as boolean;
+        }
     }
 
     async updateService(serviceId: string, selfServiceClientId: string, clientId: string, updates: ServiceNameUpdates): Promise<void> {
@@ -183,7 +188,8 @@ export default class StubLambdaFacade implements LambdaFacadeInterface {
                                 {S: "identity_verification_supported"},
                                 {S: "client_locs"},
                                 {S: "id_token_signing_algorithm"},
-                                {S: "max_age_enabled"}
+                                {S: "max_age_enabled"},
+                                {S: "pkce_enforced"}
                             ]
                         },
                         data: {S: "SAM Service as a Service Service"},
@@ -194,7 +200,8 @@ export default class StubLambdaFacade implements LambdaFacadeInterface {
                         service_type: {S: "MANDATORY"},
                         type: {S: "integration"},
                         identity_verification_supported: {S: this.identityVerificationSupported},
-                        maxAgeEnabled: {S: this.maxAgeEnabled}
+                        maxAgeEnabled: {S: this.maxAgeEnabled},
+                        pkce_enforced: {S: this.pkceEnforced}
                     }
                 ]
             }

--- a/express/src/views/clients/change-pkce-enforced.njk
+++ b/express/src/views/clients/change-pkce-enforced.njk
@@ -1,0 +1,27 @@
+{% extends "layouts/form.njk" %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+{% set pageTitle = "Change PKCE Verification Enforcement" %}
+
+{% set backLinkPath %}
+  /services/{{ serviceId }}/clients/
+{% endset %}
+
+{% set formCancelUrl = backLinkPath %}
+
+{% set formButtonText = "Confirm" %}
+
+{% block formInputs %}
+  {{ form.radiosInput(
+      "Do you want to enforce PKCE verification?",
+      "govuk-fieldset__legend--l",
+      name = "pkceEnforced",
+      items = [
+        {text: "Yes", value: "yes"},
+        {text: "No", value: "no"}
+      ],
+      isPageHeading = true
+    ) }}
+{% endblock %}

--- a/express/src/views/clients/client-details.njk
+++ b/express/src/views/clients/client-details.njk
@@ -236,6 +236,18 @@
     </div>
   {% endset %}
 
+  {% set pkceEnforcedContainer %}
+    {% if pkceEnforced %}
+      <div id="changePKCEEnforcedUri">
+        Yes
+      </div>
+    {% else %}
+      <div id="changePKCEEnforcedUri">
+        No
+      </div>
+    {% endif %}
+  {% endset %}
+
   {{ govukSummaryList({
     rows: [
       {
@@ -285,6 +297,22 @@
     ]
   }) }}
   {% endif %}
+
+  {{ govukSummaryList({
+    rows: [
+      {
+        key: {text: "Enforce PKCE"},
+        value: {html: pkceEnforcedContainer},
+        actions: {
+          items: [{
+            href: urls.changePKCEEnforcedUri,
+            text: "Change",
+            visuallyHiddenText: "change pkceEnforced value"
+          }]
+        }
+      }
+    ]
+  }) }}
 
   <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Client authentication</h2>
 

--- a/express/tests/constants.ts
+++ b/express/tests/constants.ts
@@ -164,7 +164,8 @@ export const TEST_DYNAMO_CLIENT = {
     claims: {L: [{S: TEST_CLAIM}]},
     id_token_signing_algorithm: {S: TEST_ID_SIGNING_TOKEN_ALGORITHM},
     client_locs: {L: [{S: TEST_LEVELS_OF_CONFIDENCE}]},
-    max_age_enabled: {B: TEST_BOOLEAN_SUPPORTED_ALT}
+    max_age_enabled: {B: TEST_BOOLEAN_SUPPORTED_ALT},
+    pkce_enforced: {B: TEST_BOOLEAN_SUPPORTED_ALT}
 };
 
 export const TEST_CLIENT: Client = {
@@ -192,7 +193,8 @@ export const TEST_CLIENT: Client = {
     claims: [TEST_CLAIM],
     id_token_signing_algorithm: TEST_ID_SIGNING_TOKEN_ALGORITHM,
     client_locs: [TEST_LEVELS_OF_CONFIDENCE],
-    max_age_enabled: TEST_BOOLEAN_SUPPORTED_ALT
+    max_age_enabled: TEST_BOOLEAN_SUPPORTED_ALT,
+    pkce_enforced: TEST_BOOLEAN_SUPPORTED_ALT
 };
 
 export const constructFakeJwt = (jwtBody: Record<string, unknown>): string =>

--- a/express/tests/controllers/clients.test.ts
+++ b/express/tests/controllers/clients.test.ts
@@ -34,7 +34,9 @@ import {
     showChangeClientName,
     processChangeClientName,
     showMaxAgeEnabledForm,
-    processMaxAgeEnabledForm
+    processMaxAgeEnabledForm,
+    showChangePKCEEnforcedForm,
+    processChangePKCEEnforcedForm
 } from "../../src/controllers/clients";
 import {
     TEST_ACCESS_TOKEN,
@@ -141,6 +143,7 @@ describe("showClient Controller tests", () => {
             idTokenSigningAlgorithm: TEST_CLIENT.id_token_signing_algorithm,
             identityVerificationSupported: TEST_CLIENT.identity_verification_supported,
             maxAgeEnabled: TEST_CLIENT.max_age_enabled,
+            pkceEnforced: TEST_CLIENT.pkce_enforced,
             levelsOfConfidence: TEST_LEVELS_OF_CONFIDENCE,
             contacts: TEST_CLIENT.contacts,
             urls: {
@@ -211,6 +214,7 @@ describe("showClient Controller tests", () => {
             displayedKey: TEST_STATIC_KEY_UPDATE.public_key,
             idTokenSigningAlgorithm: TEST_CLIENT.id_token_signing_algorithm,
             identityVerificationSupported: TEST_CLIENT.identity_verification_supported,
+            pkceEnforced: TEST_CLIENT.pkce_enforced,
             contacts: TEST_CLIENT.contacts,
             levelsOfConfidence: TEST_LEVELS_OF_CONFIDENCE,
             token_endpoint_auth_method: TEST_CLIENT.token_endpoint_auth_method,
@@ -283,6 +287,7 @@ describe("showClient Controller tests", () => {
             idTokenSigningAlgorithm: TEST_CLIENT.id_token_signing_algorithm,
             maxAgeEnabled: TEST_CLIENT.max_age_enabled,
             identityVerificationSupported: TEST_CLIENT.identity_verification_supported,
+            pkceEnforced: TEST_CLIENT.pkce_enforced,
             contacts: TEST_CLIENT.contacts,
             levelsOfConfidence: "",
             token_endpoint_auth_method: TEST_CLIENT.token_endpoint_auth_method,
@@ -355,6 +360,7 @@ describe("showClient Controller tests", () => {
             idTokenSigningAlgorithm: TEST_CLIENT.id_token_signing_algorithm,
             maxAgeEnabled: TEST_CLIENT.max_age_enabled,
             identityVerificationSupported: TEST_CLIENT.identity_verification_supported,
+            pkceEnforced: TEST_CLIENT.pkce_enforced,
             levelsOfConfidence: TEST_LEVELS_OF_CONFIDENCE,
             contacts: TEST_CLIENT.contacts,
             urls: {
@@ -427,6 +433,7 @@ describe("showClient Controller tests", () => {
             idTokenSigningAlgorithm: TEST_CLIENT.id_token_signing_algorithm,
             identityVerificationSupported: TEST_CLIENT.identity_verification_supported,
             maxAgeEnabled: TEST_CLIENT.max_age_enabled,
+            pkceEnforced: TEST_CLIENT.pkce_enforced,
             levelsOfConfidence: TEST_LEVELS_OF_CONFIDENCE,
             contacts: TEST_CLIENT.contacts,
             urls: {
@@ -500,6 +507,7 @@ describe("showClient Controller tests", () => {
             idTokenSigningAlgorithm: TEST_CLIENT.id_token_signing_algorithm,
             identityVerificationSupported: TEST_CLIENT.identity_verification_supported,
             maxAgeEnabled: TEST_CLIENT.max_age_enabled,
+            pkceEnforced: TEST_CLIENT.pkce_enforced,
             levelsOfConfidence: TEST_LEVELS_OF_CONFIDENCE,
             contacts: TEST_CLIENT.contacts,
             urls: {
@@ -571,6 +579,7 @@ describe("showClient Controller tests", () => {
             idTokenSigningAlgorithm: TEST_CLIENT.id_token_signing_algorithm,
             maxAgeEnabled: TEST_CLIENT.max_age_enabled,
             identityVerificationSupported: false,
+            pkceEnforced: false,
             contacts: TEST_CLIENT.contacts,
             urls: {
                 changeClientName: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${
@@ -2991,6 +3000,151 @@ describe("processEnterIdentityVerificationForm controller tests for updating fla
             clientId: TEST_CLIENT_ID,
             errorMessages: {
                 "identityVerificationSupported-options": "Select yes if you want to enable identity verification"
+            }
+        });
+    });
+});
+
+describe("showChangePKCEEnforcedForm controller tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("renders the expected template with the expected values", () => {
+        const mockRequest = request({
+            context: {
+                serviceId: TEST_SERVICE_ID
+            },
+            params: {
+                selfServiceClientId: TEST_SELF_SERVICE_CLIENT_ID,
+                clientId: TEST_CLIENT_ID
+            }
+        });
+        const mockResponse = response();
+
+        showChangePKCEEnforcedForm(mockRequest, mockResponse, mockNext);
+
+        expect(mockResponse.render).toHaveBeenCalledWith("clients/change-pkce-enforced.njk", {
+            serviceId: TEST_SERVICE_ID,
+            selfServiceClientId: TEST_SELF_SERVICE_CLIENT_ID,
+            clientId: TEST_CLIENT_ID
+        });
+    });
+});
+
+describe("processChangePKCEEnforcedForm controller tests for updating flag", () => {
+    const s4UpdateClientSpy = jest.spyOn(SelfServiceServicesService.prototype, "updateClient");
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it("calls s4 change this flag to true and updates the value and then redirects to /clients", async () => {
+        s4UpdateClientSpy.mockResolvedValue();
+
+        const mockReq = request({
+            body: {
+                pkceEnforced: TEST_BOOLEAN_SUPPORTED_TX
+            },
+            params: {
+                selfServiceClientId: TEST_SELF_SERVICE_CLIENT_ID,
+                clientId: TEST_CLIENT_ID
+            },
+            context: {
+                serviceId: TEST_SERVICE_ID
+            },
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT,
+                id: TEST_SESSION_ID
+            },
+            ip: TEST_IP_ADDRESS
+        });
+        const mockRes = response();
+        await processChangePKCEEnforcedForm(mockReq, mockRes);
+
+        expect(s4UpdateClientSpy).toHaveBeenCalledWith(
+            TEST_SERVICE_ID,
+            TEST_SELF_SERVICE_CLIENT_ID,
+            TEST_CLIENT_ID,
+            {
+                pkce_enforced: TEST_BOOLEAN_SUPPORTED
+            },
+            TEST_ACCESS_TOKEN
+        );
+
+        expect(mockReq.session.updatedField).toStrictEqual("PKCE enforced");
+        expect(mockRes.redirect).toHaveBeenCalledWith("/services/" + TEST_SERVICE_ID + "/clients");
+    });
+
+    it("calls s4 change this flag to false and updates the value and then redirects to /clients", async () => {
+        s4UpdateClientSpy.mockResolvedValue();
+
+        const mockReq = request({
+            body: {
+                pkceEnforced: TEST_BOOLEAN_SUPPORTED_ALT_TX
+            },
+            params: {
+                selfServiceClientId: TEST_SELF_SERVICE_CLIENT_ID,
+                clientId: TEST_CLIENT_ID
+            },
+            context: {
+                serviceId: TEST_SERVICE_ID
+            },
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT,
+                id: TEST_SESSION_ID
+            },
+            ip: TEST_IP_ADDRESS
+        });
+        const mockRes = response();
+        await processChangePKCEEnforcedForm(mockReq, mockRes);
+
+        expect(s4UpdateClientSpy).toHaveBeenCalledWith(
+            TEST_SERVICE_ID,
+            TEST_SELF_SERVICE_CLIENT_ID,
+            TEST_CLIENT_ID,
+            {
+                pkce_enforced: TEST_BOOLEAN_SUPPORTED_ALT
+            },
+            TEST_ACCESS_TOKEN
+        );
+
+        expect(mockReq.session.updatedField).toStrictEqual("PKCE enforced");
+        expect(mockRes.redirect).toHaveBeenCalledWith("/services/" + TEST_SERVICE_ID + "/clients");
+    });
+
+    it("does not call s4 and re-renders the same template if the user submits without selecting an option", async () => {
+        s4UpdateClientSpy.mockResolvedValue();
+
+        const mockReq = request({
+            body: {},
+            params: {
+                selfServiceClientId: TEST_SELF_SERVICE_CLIENT_ID,
+                clientId: TEST_CLIENT_ID
+            },
+            context: {
+                serviceId: TEST_SERVICE_ID
+            },
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT,
+                id: TEST_SESSION_ID
+            },
+            ip: TEST_IP_ADDRESS
+        });
+        const mockRes = response();
+        await processChangePKCEEnforcedForm(mockReq, mockRes);
+
+        expect(s4UpdateClientSpy).not.toHaveBeenCalled();
+        expect(mockRes.render).toHaveBeenCalledWith("clients/change-pkce-enforced.njk", {
+            serviceId: TEST_SERVICE_ID,
+            selfServiceClientId: TEST_SELF_SERVICE_CLIENT_ID,
+            clientId: TEST_CLIENT_ID,
+            errorMessages: {
+                "pkceEnforced-options": "Select yes if you want to enforce PKCE"
             }
         });
     });

--- a/express/tests/controllers/clients.test.ts
+++ b/express/tests/controllers/clients.test.ts
@@ -166,7 +166,8 @@ describe("showClient Controller tests", () => {
                     "/services/service#123/clients/ajedebd2343/456/change-id-token-signing-algorithm?algorithm=ES256",
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=${TEST_CLAIM}`,
                 changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`,
-                changeMaxAgeEnabled: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-max-age-enabled`
+                changeMaxAgeEnabled: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-max-age-enabled`,
+                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`
             },
             basicAuthCreds: {
                 username: TEST_BASIC_AUTH_USERNAME,
@@ -236,7 +237,8 @@ describe("showClient Controller tests", () => {
                 changeIdVerificationEnabledUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/enter-identity-verification`,
                 changeMaxAgeEnabled: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-max-age-enabled`,
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=`,
-                changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`
+                changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`,
+                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`
             },
             basicAuthCreds: {
                 username: TEST_BASIC_AUTH_USERNAME,
@@ -306,7 +308,8 @@ describe("showClient Controller tests", () => {
                 changeIdVerificationEnabledUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/enter-identity-verification`,
                 changeMaxAgeEnabled: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-max-age-enabled`,
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=${TEST_CLIENT.claims}`,
-                changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`
+                changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`,
+                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`
             },
             basicAuthCreds: {
                 username: TEST_BASIC_AUTH_USERNAME,
@@ -377,7 +380,8 @@ describe("showClient Controller tests", () => {
                 changeIdTokenSigningAlgorithm:
                     "/services/service#123/clients/ajedebd2343/456/change-id-token-signing-algorithm?algorithm=ES256",
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=${TEST_CLAIM}`,
-                changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`
+                changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`,
+                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`
             },
             basicAuthCreds: {
                 username: TEST_BASIC_AUTH_USERNAME,
@@ -447,7 +451,8 @@ describe("showClient Controller tests", () => {
                 changeIdTokenSigningAlgorithm:
                     "/services/service#123/clients/ajedebd2343/456/change-id-token-signing-algorithm?algorithm=ES256",
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=${TEST_CLAIM}`,
-                changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`
+                changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`,
+                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`
             },
             basicAuthCreds: {
                 username: TEST_BASIC_AUTH_USERNAME,
@@ -519,7 +524,8 @@ describe("showClient Controller tests", () => {
                 changeIdTokenSigningAlgorithm:
                     "/services/service#123/clients/ajedebd2343/456/change-id-token-signing-algorithm?algorithm=ES256",
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=${TEST_CLAIM}`,
-                changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`
+                changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`,
+                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`
             },
             basicAuthCreds: {
                 username: TEST_BASIC_AUTH_USERNAME,
@@ -590,7 +596,8 @@ describe("showClient Controller tests", () => {
                 changeIdTokenSigningAlgorithm:
                     "/services/service#123/clients/ajedebd2343/456/change-id-token-signing-algorithm?algorithm=ES256",
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=`,
-                changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`
+                changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`,
+                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`
             },
             basicAuthCreds: {
                 username: TEST_BASIC_AUTH_USERNAME,

--- a/express/tests/services/lambda-facade/StubLambdaFacade.test.ts
+++ b/express/tests/services/lambda-facade/StubLambdaFacade.test.ts
@@ -30,11 +30,13 @@ describe("Lambda Facade class tests", () => {
                                 {S: "identity_verification_supported"},
                                 {S: "client_locs"},
                                 {S: "id_token_signing_algorithm"},
-                                {S: "max_age_enabled"}
+                                {S: "max_age_enabled"},
+                                {S: "pkce_enforced"}
                             ]
                         },
                         id_token_signing_algorithm: {S: "ES256"},
                         identity_verification_supported: {S: false},
+                        pkce_enforced: {S: false},
                         pk: {S: "service#277619fe-c056-45be-bc2a-43310613913c"},
                         post_logout_redirect_uris: {L: []},
                         public_key: {

--- a/ui-automation-tests/acceptance-features/clients/change-pkce-enforced.feature
+++ b/ui-automation-tests/acceptance-features/clients/change-pkce-enforced.feature
@@ -1,0 +1,51 @@
+Feature: Users can toggle PKCE enforced
+
+Background:
+    Given the user is signed in
+    And they goto on the test service page
+    When they click on the link that points to "/change-pkce-enforced"
+    Then they should be redirected to a page with the title "Change PKCE Verification Enforcement - GOV.UK One Login"
+    When they select the "No" radio button
+    And they click the Confirm button
+    Then they should be redirected to a page with the title "Client details - GOV.UK One Login"
+    And they should see the exact value "No" in the PKCE enforced field
+
+Rule: The user can navigate back to the client page by clicking cancel
+    @ci @smoke
+    Scenario: The user clicks cancel
+        Given they should see the exact value "No" in the PKCE enforced field
+        Then they click on the link that points to "/change-pkce-enforced"
+        And they should be redirected to a page with the title "Change PKCE Verification Enforcement - GOV.UK One Login"
+        When they click on the "Cancel" link
+        Then they should be redirected to a page with the title "Client details - GOV.UK One Login"
+        And they should see the exact value "No" in the PKCE enforced field
+        And they should not see the text "You have changed your PKCE enforced"
+
+Rule: The user can navigate back to the client page by clicking the back link
+    @ci @smoke
+    Scenario: The user clicks cancel
+        Given they should see the exact value "No" in the PKCE enforced field
+        Then they click on the link that points to "/change-pkce-enforced"
+        And they should be redirected to a page with the title "Change PKCE Verification Enforcement - GOV.UK One Login"
+        When they click on the "Back" link
+        Then they should be redirected to a page with the title "Client details - GOV.UK One Login"
+        And they should see the exact value "No" in the PKCE enforced field
+        And they should not see the text "You have changed your PKCE enforced"
+
+Rule: The user can enable and then disable PKCE enforced
+    @ci @smoke
+    Scenario: The user clicks yes and then confirm
+        Given they should see the exact value "No" in the PKCE enforced field
+        Then they click on the link that points to "/change-pkce-enforced"
+        And they should be redirected to a page with the title "Change PKCE Verification Enforcement - GOV.UK One Login"
+        When they select the "Yes" radio button
+        And they click the Confirm button
+        Then they should be redirected to a page with the title "Client details - GOV.UK One Login"
+        And they should see the exact value "Yes" in the PKCE enforced field
+        And they should see the text "You have changed your PKCE enforced"
+        Then they click on the link that points to "/change-pkce-enforced"
+        And they should be redirected to a page with the title "Change PKCE Verification Enforcement - GOV.UK One Login"
+        When they select the "No" radio button
+        And they click the Confirm button
+        Then they should be redirected to a page with the title "Client details - GOV.UK One Login"
+        And they should see the exact value "No" in the PKCE enforced field

--- a/ui-automation-tests/support/steps/clients-steps.ts
+++ b/ui-automation-tests/support/steps/clients-steps.ts
@@ -17,7 +17,8 @@ const fields = {
     "sector identifier uri": "sectorIdentifierUri",
     "identity verification enabled": "idVerificationEnabledUri",
     claims: "claimsUri",
-    "id token signing algorithm": "idTokenSigningAlgorithm"
+    "id token signing algorithm": "idTokenSigningAlgorithm",
+    "PKCE enforced": "changePKCEEnforcedUri"
 };
 
 Then("they should see the value for the Client ID {string}", async function (this: TestContext, text) {


### PR DESCRIPTION
## Checklist

-   [x] this pull request meets the acceptance criteria of the ticket

-   [x] this branch is up-to-date with the main branch

    `git fetch --all && git rebase origin/main`

-   [x] these changes are backwards compatible (no breaking changes)

    -   all methods signatures and return values are the same
    -   any replaced methods are marked as `@deprecated`

-   [x] tests have been written to cover any new or updated functionality

-   [x] new configuration parameters have been deployed to all environments, see [configuration management](https://govukverify.atlassian.net/l/cp/N7q3Vh3r).

-   [x] all external infrastructure dependencies have been updated in all environments

## Changes

Added PKCE Enforced to the client registry, in which if enabled the request must use the code_challenge
