### PR TITLE
ATO-1730/Allow RP to set landing page url

### DIFF
--- a/express/@types/client.d.ts
+++ b/express/@types/client.d.ts
@@ -25,6 +25,7 @@ export interface ClientFromDynamo {
     client_locs?: string[];
     max_age_enabled?: boolean;
     pkce_enforced: boolean;
+    landing_page_url?: string;
 }
 
 export interface Client {
@@ -54,4 +55,5 @@ export interface Client {
     client_locs?: string[];
     max_age_enabled?: boolean;
     pkce_enforced: boolean;
+    landing_page_url?: string;
 }

--- a/express/src/controllers/clients.ts
+++ b/express/src/controllers/clients.ts
@@ -38,12 +38,16 @@ export const showClient: RequestHandler = async (req, res) => {
         displayedKey = client.jwksUri;
     }
 
+    const successBannerMessage = req.session.updatedField
+        ? generateSuccessBannerMessage(req.session.updatedField, identityVerificationSupported, landingPageUrl)
+        : undefined;
+
     res.render("clients/client-details.njk", {
         clientId: authClientId,
         selfServiceClientId: selfServiceClientId,
         serviceId: serviceId,
         serviceName: serviceName,
-        updatedField: req.session.updatedField,
+        successBannerMessage: successBannerMessage,
         redirectUris: redirectUris,
         scopesRequired: client.scopes,
         ...(client.token_endpoint_auth_method === "client_secret_post"
@@ -115,6 +119,23 @@ export const showClient: RequestHandler = async (req, res) => {
     // TODO we need to use a flash message package for Express
     req.session.serviceName = client.serviceName ? client.serviceName : client.clientName;
     req.session.updatedField = undefined;
+};
+
+const generateSuccessBannerMessage = (updatedField?: string, identityVerificationSupported?: boolean, landingPageUrl?: string) => {
+    let message;
+    if (updatedField === "identity verification") {
+        if (identityVerificationSupported) {
+            message = "You have enabled identity verification.";
+            if (!landingPageUrl) {
+                message += " It is strongly recommended that you set a landing page URI.";
+            }
+        } else {
+            message = "You have disabled identity verification.";
+        }
+    } else {
+        message = `You have changed your ${updatedField}`;
+    }
+    return message;
 };
 
 export const showGoLivePage: RequestHandler = (req, res) => {
@@ -1025,5 +1046,3 @@ export const processChangeLandingPageUrlForm: RequestHandler = async (req: Reque
 
     res.redirect(`/services/${req.context.serviceId}/clients`);
 };
-
-

--- a/express/src/lib/models/client-utils.ts
+++ b/express/src/lib/models/client-utils.ts
@@ -27,6 +27,7 @@ export function dynamoClientToDomainClient(client: ClientFromDynamo): Client {
         id_token_signing_algorithm: client.id_token_signing_algorithm,
         client_locs: client.client_locs,
         max_age_enabled: client.max_age_enabled,
-        pkce_enforced: client.pkce_enforced
+        pkce_enforced: client.pkce_enforced,
+        landing_page_url: client.landing_page_url
     };
 }

--- a/express/src/routes/clients.ts
+++ b/express/src/routes/clients.ts
@@ -40,7 +40,9 @@ import {
     showMaxAgeEnabledForm,
     processMaxAgeEnabledForm,
     showChangePKCEEnforcedForm,
-    processChangePKCEEnforcedForm
+    processChangePKCEEnforcedForm,
+    showChangeLandingPageUrlForm,
+    processChangeLandingPageUrlForm
 } from "../controllers/clients";
 import validateKeySource from "../middleware/validate-public-key";
 import validateUri from "../middleware/validators/uri-validator";
@@ -134,3 +136,8 @@ router
 router.route("/:clientId/:selfServiceClientId/change-max-age-enabled").get(showMaxAgeEnabledForm).post(processMaxAgeEnabledForm);
 
 router.route("/:clientId/:selfServiceClientId/change-pkce-enforced").get(showChangePKCEEnforcedForm).post(processChangePKCEEnforcedForm);
+
+router
+    .route("/:clientId/:selfServiceClientId/change-landing-page-url")
+    .get(showChangeLandingPageUrlForm)
+    .post(validateUri("clients/change-landing-page-url.njk", "landingPageUrl"), processChangeLandingPageUrlForm);

--- a/express/src/services/lambda-facade/StubLambdaFacade.ts
+++ b/express/src/services/lambda-facade/StubLambdaFacade.ts
@@ -25,6 +25,7 @@ export default class StubLambdaFacade implements LambdaFacadeInterface {
     private id_token_signing_algorithm = "ES256";
     private maxAgeEnabled = false;
     private pkceEnforced = false;
+    private landingPageUrl: string | null = null;
 
     private user: DynamoUser = {
         last_name: {S: "we haven't collected this last name"},
@@ -117,6 +118,10 @@ export default class StubLambdaFacade implements LambdaFacadeInterface {
         if (typeof updates.pkce_enforced !== "undefined") {
             this.pkceEnforced = updates.pkce_enforced as boolean;
         }
+
+        if (updates.landing_page_url) {
+            this.landingPageUrl = updates.landing_page_url as string;
+        }
     }
 
     async updateService(serviceId: string, selfServiceClientId: string, clientId: string, updates: ServiceNameUpdates): Promise<void> {
@@ -201,7 +206,8 @@ export default class StubLambdaFacade implements LambdaFacadeInterface {
                         type: {S: "integration"},
                         identity_verification_supported: {S: this.identityVerificationSupported},
                         maxAgeEnabled: {S: this.maxAgeEnabled},
-                        pkce_enforced: {S: this.pkceEnforced}
+                        pkce_enforced: {S: this.pkceEnforced},
+                        ...(this.landingPageUrl && {landing_page_url: {S: this.landingPageUrl}})
                     }
                 ]
             }

--- a/express/src/views/clients/change-landing-page-url.njk
+++ b/express/src/views/clients/change-landing-page-url.njk
@@ -1,0 +1,18 @@
+{% extends "layouts/form.njk" %}
+
+{% set pageTitle = "Enter landing page URI" %}
+
+{% set backLinkPath %}
+  /services/{{ serviceId }}/clients/
+{% endset %}
+
+{% set formCancelUrl = backLinkPath %}
+{% set formButtonText = "Confirm" %}
+
+{% block beforeForm %}
+  <h1 class="govuk-heading-l govuk-!-margin-top-3">Enter landing page URI</h1>
+{% endblock %}
+
+{% block formInputs %}
+  {{ form.uriInput("", "landingPageUrl", "") }}
+{% endblock %}

--- a/express/src/views/clients/client-details.njk
+++ b/express/src/views/clients/client-details.njk
@@ -91,6 +91,14 @@
   {% endset %}
 {% endif %}
 
+{% set landingPageUrlContainer %}
+    {% if landingPageUrl and landingPageUrl.length > 0 and landingPageUrl[0] !== "" %}
+      <div id="landingPageUrl">{{ landingPageUrl }}</div>
+    {% else %}
+      <div id="landingPageUrl">Not added yet</div>
+    {% endif %}
+  {% endset %}
+
   {{ govukSummaryList({
     rows: [
       {
@@ -192,7 +200,18 @@
             visuallyHiddenText: "Max Age Enabled"
           }]
         }
-      }
+      },
+      {
+          key: {text: "Landing page URI"},
+          value: {html: landingPageUrlContainer},
+          actions: {
+            items: [{
+              href: urls.changeLandingPageUrl,
+              text: "Change",
+              visuallyHiddenText: "Landing page URI"
+            }]
+          }
+        }
     ]
   }) }}
 

--- a/express/src/views/clients/client-details.njk
+++ b/express/src/views/clients/client-details.njk
@@ -16,10 +16,10 @@
 {% endset %}
 
 {% block mainContent %}
-  {% if updatedField %}
+  {% if successBannerMessage %}
     {% call govukNotificationBanner({type: 'success'}) %}
       <h3 class="govuk-notification-banner__heading">
-        You have changed your {{ updatedField }}
+        {{ successBannerMessage }}
       </h3>
     {% endcall %}
   {% endif %}

--- a/express/src/views/clients/enter-identity-verification.njk
+++ b/express/src/views/clients/enter-identity-verification.njk
@@ -19,7 +19,13 @@
       "govuk-fieldset__legend--l",
       name = "identityVerificationSupported",
       items = [
-        {text: "Yes", value: "yes"},
+        {
+            text: "Yes",
+            value: "yes",
+            hint: {
+                text: "If you need identity verification, it is strongly recommended that you set a landing page URI to ensure that users can be returned to your service after in-person identity checks."
+                }
+        },
         {text: "No", value: "no"}
       ],
       isPageHeading = true

--- a/express/tests/constants.ts
+++ b/express/tests/constants.ts
@@ -123,6 +123,7 @@ export const TEST_SERVICE_TYPE = "serviceType";
 export const TEST_SUBJECT_TYPE = "subject";
 export const TEST_BACK_CHANNEL_LOGOUT_URI = "someBackChannel";
 export const TEST_SECTOR_IDENTIFIER_URI = "someSectorIdentifier";
+export const TEST_LANDING_PAGE_URL = "someLandingPageUrl";
 export const TEST_TOKEN_AUTH_METHOD = "private_key_jwt";
 export const TEST_TOKEN_AUTH_METHOD_ALT = "client_secret_post";
 export const TEST_TYPE = "someType";
@@ -165,7 +166,8 @@ export const TEST_DYNAMO_CLIENT = {
     id_token_signing_algorithm: {S: TEST_ID_SIGNING_TOKEN_ALGORITHM},
     client_locs: {L: [{S: TEST_LEVELS_OF_CONFIDENCE}]},
     max_age_enabled: {B: TEST_BOOLEAN_SUPPORTED_ALT},
-    pkce_enforced: {B: TEST_BOOLEAN_SUPPORTED_ALT}
+    pkce_enforced: {B: TEST_BOOLEAN_SUPPORTED_ALT},
+    landing_page_url: {S: TEST_LANDING_PAGE_URL}
 };
 
 export const TEST_CLIENT: Client = {
@@ -194,7 +196,8 @@ export const TEST_CLIENT: Client = {
     id_token_signing_algorithm: TEST_ID_SIGNING_TOKEN_ALGORITHM,
     client_locs: [TEST_LEVELS_OF_CONFIDENCE],
     max_age_enabled: TEST_BOOLEAN_SUPPORTED_ALT,
-    pkce_enforced: TEST_BOOLEAN_SUPPORTED_ALT
+    pkce_enforced: TEST_BOOLEAN_SUPPORTED_ALT,
+    landing_page_url: TEST_LANDING_PAGE_URL
 };
 
 export const constructFakeJwt = (jwtBody: Record<string, unknown>): string =>

--- a/express/tests/controllers/clients.test.ts
+++ b/express/tests/controllers/clients.test.ts
@@ -36,7 +36,9 @@ import {
     showMaxAgeEnabledForm,
     processMaxAgeEnabledForm,
     showChangePKCEEnforcedForm,
-    processChangePKCEEnforcedForm
+    processChangePKCEEnforcedForm,
+    showChangeLandingPageUrlForm,
+    processChangeLandingPageUrlForm
 } from "../../src/controllers/clients";
 import {
     TEST_ACCESS_TOKEN,
@@ -59,6 +61,7 @@ import {
     TEST_EMAIL,
     TEST_ID_SIGNING_TOKEN_ALGORITHM,
     TEST_IP_ADDRESS,
+    TEST_LANDING_PAGE_URL,
     TEST_LEVELS_OF_CONFIDENCE,
     TEST_LEVELS_OF_CONFIDENCE_ALT,
     TEST_POST_LOGOUT_REDIRECT_URI,
@@ -131,7 +134,7 @@ describe("showClient Controller tests", () => {
             serviceId: TEST_SERVICE_ID,
             serviceName: TEST_CLIENT.serviceName,
             token_endpoint_auth_method: TEST_TOKEN_AUTH_METHOD,
-            updatedField: undefined,
+            successBannerMessage: undefined,
             redirectUris: TEST_CLIENT.redirectUris,
             scopesRequired: TEST_CLIENT.scopes,
             userPublicKey: TEST_CLIENT.publicKey,
@@ -144,6 +147,7 @@ describe("showClient Controller tests", () => {
             identityVerificationSupported: TEST_CLIENT.identity_verification_supported,
             maxAgeEnabled: TEST_CLIENT.max_age_enabled,
             pkceEnforced: TEST_CLIENT.pkce_enforced,
+            landingPageUrl: TEST_LANDING_PAGE_URL,
             levelsOfConfidence: TEST_LEVELS_OF_CONFIDENCE,
             contacts: TEST_CLIENT.contacts,
             urls: {
@@ -170,7 +174,10 @@ describe("showClient Controller tests", () => {
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=${TEST_CLAIM}`,
                 changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`,
                 changeMaxAgeEnabled: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-max-age-enabled`,
-                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`
+                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`,
+                changeLandingPageUrl: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${
+                    TEST_CLIENT.dynamoServiceId
+                }/change-landing-page-url?landingPageUrl=${encodeURIComponent(TEST_CLIENT.landing_page_url as string)}`
             },
             basicAuthCreds: {
                 username: TEST_BASIC_AUTH_USERNAME,
@@ -203,7 +210,7 @@ describe("showClient Controller tests", () => {
             selfServiceClientId: TEST_CLIENT.dynamoServiceId,
             serviceId: TEST_SERVICE_ID,
             serviceName: TEST_CLIENT.serviceName,
-            updatedField: undefined,
+            successBannerMessage: undefined,
             redirectUris: TEST_CLIENT.redirectUris,
             scopesRequired: TEST_CLIENT.scopes,
             userPublicKey: TEST_CLIENT.publicKey,
@@ -215,6 +222,7 @@ describe("showClient Controller tests", () => {
             idTokenSigningAlgorithm: TEST_CLIENT.id_token_signing_algorithm,
             identityVerificationSupported: TEST_CLIENT.identity_verification_supported,
             pkceEnforced: TEST_CLIENT.pkce_enforced,
+            landingPageUrl: TEST_LANDING_PAGE_URL,
             contacts: TEST_CLIENT.contacts,
             levelsOfConfidence: TEST_LEVELS_OF_CONFIDENCE,
             token_endpoint_auth_method: TEST_CLIENT.token_endpoint_auth_method,
@@ -242,7 +250,10 @@ describe("showClient Controller tests", () => {
                 changeMaxAgeEnabled: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-max-age-enabled`,
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=`,
                 changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`,
-                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`
+                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`,
+                changeLandingPageUrl: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${
+                    TEST_CLIENT.dynamoServiceId
+                }/change-landing-page-url?landingPageUrl=${encodeURIComponent(TEST_CLIENT.landing_page_url as string)}`
             },
             basicAuthCreds: {
                 username: TEST_BASIC_AUTH_USERNAME,
@@ -275,7 +286,7 @@ describe("showClient Controller tests", () => {
             selfServiceClientId: TEST_CLIENT.dynamoServiceId,
             serviceId: TEST_SERVICE_ID,
             serviceName: TEST_CLIENT.serviceName,
-            updatedField: undefined,
+            successBannerMessage: undefined,
             redirectUris: TEST_CLIENT.redirectUris,
             scopesRequired: TEST_CLIENT.scopes,
             userPublicKey: TEST_CLIENT.publicKey,
@@ -288,6 +299,7 @@ describe("showClient Controller tests", () => {
             maxAgeEnabled: TEST_CLIENT.max_age_enabled,
             identityVerificationSupported: TEST_CLIENT.identity_verification_supported,
             pkceEnforced: TEST_CLIENT.pkce_enforced,
+            landingPageUrl: TEST_LANDING_PAGE_URL,
             contacts: TEST_CLIENT.contacts,
             levelsOfConfidence: "",
             token_endpoint_auth_method: TEST_CLIENT.token_endpoint_auth_method,
@@ -314,7 +326,10 @@ describe("showClient Controller tests", () => {
                 changeMaxAgeEnabled: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-max-age-enabled`,
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=${TEST_CLIENT.claims}`,
                 changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`,
-                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`
+                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`,
+                changeLandingPageUrl: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${
+                    TEST_CLIENT.dynamoServiceId
+                }/change-landing-page-url?landingPageUrl=${encodeURIComponent(TEST_CLIENT.landing_page_url as string)}`
             },
             basicAuthCreds: {
                 username: TEST_BASIC_AUTH_USERNAME,
@@ -348,7 +363,7 @@ describe("showClient Controller tests", () => {
             serviceId: TEST_SERVICE_ID,
             serviceName: TEST_CLIENT.serviceName,
             token_endpoint_auth_method: TEST_TOKEN_AUTH_METHOD,
-            updatedField: undefined,
+            successBannerMessage: undefined,
             redirectUris: TEST_CLIENT.redirectUris,
             scopesRequired: TEST_CLIENT.scopes,
             userPublicKey: "",
@@ -361,6 +376,7 @@ describe("showClient Controller tests", () => {
             maxAgeEnabled: TEST_CLIENT.max_age_enabled,
             identityVerificationSupported: TEST_CLIENT.identity_verification_supported,
             pkceEnforced: TEST_CLIENT.pkce_enforced,
+            landingPageUrl: TEST_LANDING_PAGE_URL,
             levelsOfConfidence: TEST_LEVELS_OF_CONFIDENCE,
             contacts: TEST_CLIENT.contacts,
             urls: {
@@ -387,7 +403,10 @@ describe("showClient Controller tests", () => {
                     "/services/service#123/clients/ajedebd2343/456/change-id-token-signing-algorithm?algorithm=ES256",
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=${TEST_CLAIM}`,
                 changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`,
-                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`
+                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`,
+                changeLandingPageUrl: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${
+                    TEST_CLIENT.dynamoServiceId
+                }/change-landing-page-url?landingPageUrl=${encodeURIComponent(TEST_CLIENT.landing_page_url as string)}`
             },
             basicAuthCreds: {
                 username: TEST_BASIC_AUTH_USERNAME,
@@ -421,7 +440,7 @@ describe("showClient Controller tests", () => {
             serviceId: TEST_SERVICE_ID,
             serviceName: TEST_CLIENT.serviceName,
             token_endpoint_auth_method: TEST_TOKEN_AUTH_METHOD_ALT,
-            updatedField: undefined,
+            successBannerMessage: undefined,
             redirectUris: TEST_CLIENT.redirectUris,
             scopesRequired: TEST_CLIENT.scopes,
             client_secret: TEST_CLIENT.client_secret,
@@ -434,6 +453,7 @@ describe("showClient Controller tests", () => {
             identityVerificationSupported: TEST_CLIENT.identity_verification_supported,
             maxAgeEnabled: TEST_CLIENT.max_age_enabled,
             pkceEnforced: TEST_CLIENT.pkce_enforced,
+            landingPageUrl: TEST_LANDING_PAGE_URL,
             levelsOfConfidence: TEST_LEVELS_OF_CONFIDENCE,
             contacts: TEST_CLIENT.contacts,
             urls: {
@@ -459,7 +479,10 @@ describe("showClient Controller tests", () => {
                     "/services/service#123/clients/ajedebd2343/456/change-id-token-signing-algorithm?algorithm=ES256",
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=${TEST_CLAIM}`,
                 changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`,
-                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`
+                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`,
+                changeLandingPageUrl: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${
+                    TEST_CLIENT.dynamoServiceId
+                }/change-landing-page-url?landingPageUrl=${encodeURIComponent(TEST_CLIENT.landing_page_url as string)}`
             },
             basicAuthCreds: {
                 username: TEST_BASIC_AUTH_USERNAME,
@@ -495,7 +518,7 @@ describe("showClient Controller tests", () => {
             serviceId: TEST_SERVICE_ID,
             serviceName: TEST_CLIENT.serviceName,
             token_endpoint_auth_method: TEST_TOKEN_AUTH_METHOD_ALT,
-            updatedField: undefined,
+            successBannerMessage: undefined,
             redirectUris: TEST_CLIENT.redirectUris,
             scopesRequired: TEST_CLIENT.scopes,
             client_secret: "",
@@ -508,6 +531,7 @@ describe("showClient Controller tests", () => {
             identityVerificationSupported: TEST_CLIENT.identity_verification_supported,
             maxAgeEnabled: TEST_CLIENT.max_age_enabled,
             pkceEnforced: TEST_CLIENT.pkce_enforced,
+            landingPageUrl: TEST_LANDING_PAGE_URL,
             levelsOfConfidence: TEST_LEVELS_OF_CONFIDENCE,
             contacts: TEST_CLIENT.contacts,
             urls: {
@@ -533,7 +557,10 @@ describe("showClient Controller tests", () => {
                     "/services/service#123/clients/ajedebd2343/456/change-id-token-signing-algorithm?algorithm=ES256",
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=${TEST_CLAIM}`,
                 changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`,
-                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`
+                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`,
+                changeLandingPageUrl: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${
+                    TEST_CLIENT.dynamoServiceId
+                }/change-landing-page-url?landingPageUrl=${encodeURIComponent(TEST_CLIENT.landing_page_url as string)}`
             },
             basicAuthCreds: {
                 username: TEST_BASIC_AUTH_USERNAME,
@@ -567,7 +594,7 @@ describe("showClient Controller tests", () => {
             serviceId: TEST_SERVICE_ID,
             serviceName: TEST_CLIENT.serviceName,
             token_endpoint_auth_method: TEST_TOKEN_AUTH_METHOD,
-            updatedField: undefined,
+            successBannerMessage: undefined,
             redirectUris: TEST_CLIENT.redirectUris,
             scopesRequired: TEST_CLIENT.scopes,
             userPublicKey: TEST_CLIENT.publicKey,
@@ -580,6 +607,7 @@ describe("showClient Controller tests", () => {
             maxAgeEnabled: TEST_CLIENT.max_age_enabled,
             identityVerificationSupported: false,
             pkceEnforced: false,
+            landingPageUrl: TEST_LANDING_PAGE_URL,
             contacts: TEST_CLIENT.contacts,
             urls: {
                 changeClientName: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${
@@ -606,7 +634,10 @@ describe("showClient Controller tests", () => {
                     "/services/service#123/clients/ajedebd2343/456/change-id-token-signing-algorithm?algorithm=ES256",
                 changeClaims: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-claims?claims=`,
                 changeScopes: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-scopes?scopes=${TEST_SCOPES_IN[0]}`,
-                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`
+                changePKCEEnforcedUri: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${TEST_CLIENT.dynamoServiceId}/change-pkce-enforced`,
+                changeLandingPageUrl: `/services/${TEST_SERVICE_ID}/clients/${TEST_CLIENT.authClientId}/${
+                    TEST_CLIENT.dynamoServiceId
+                }/change-landing-page-url?landingPageUrl=${encodeURIComponent(TEST_CLIENT.landing_page_url as string)}`
             },
             basicAuthCreds: {
                 username: TEST_BASIC_AUTH_USERNAME,
@@ -3434,5 +3465,76 @@ describe("processMaxAgeEnabled controller tests for updating flag", () => {
                 "maxAgeEnabled-options": "Select yes if you want to enable Max Age"
             }
         });
+    });
+});
+describe("showChangeLandingPageUrlForm controller tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("renders the expected template with the expected values", () => {
+        const mockRequest = request({
+            context: {
+                serviceId: TEST_SERVICE_ID
+            },
+            params: {
+                selfServiceClientId: TEST_SELF_SERVICE_CLIENT_ID,
+                clientId: TEST_CLIENT_ID
+            },
+            query: {
+                landingPageUrl: TEST_LANDING_PAGE_URL
+            }
+        });
+        const mockResponse = response();
+
+        showChangeLandingPageUrlForm(mockRequest, mockResponse, mockNext);
+
+        expect(mockResponse.render).toHaveBeenCalledWith("clients/change-landing-page-url.njk", {
+            serviceId: TEST_SERVICE_ID,
+            selfServiceClientId: TEST_SELF_SERVICE_CLIENT_ID,
+            clientId: TEST_CLIENT_ID,
+            values: {
+                landingPageUrl: TEST_LANDING_PAGE_URL
+            }
+        });
+    });
+});
+
+describe("processChangeLandingPageUrlForm controller tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("calls s4 update client with the new landing page url and then redirects to`/services/:serviceId/clients", async () => {
+        s4UpdateClientSpy.mockResolvedValue();
+
+        const mockRequest = request({
+            session: {
+                authenticationResult: TEST_AUTHENTICATION_RESULT
+            },
+            params: {
+                selfServiceClientId: TEST_SELF_SERVICE_CLIENT_ID,
+                clientId: TEST_CLIENT_ID
+            },
+            body: {
+                landingPageUrl: TEST_LANDING_PAGE_URL
+            },
+            context: {
+                serviceId: TEST_SERVICE_ID
+            }
+        });
+        const mockResponse = response();
+
+        await processChangeLandingPageUrlForm(mockRequest, mockResponse, mockNext);
+
+        expect(s4UpdateClientSpy).toHaveBeenCalledWith(
+            TEST_SERVICE_ID,
+            TEST_SELF_SERVICE_CLIENT_ID,
+            TEST_CLIENT_ID,
+            {landing_page_url: TEST_LANDING_PAGE_URL},
+            TEST_AUTHENTICATION_RESULT.AccessToken
+        );
+        expect(mockRequest.session.updatedField).toBe("Landing page URI");
+        expect(mockResponse.redirect).toHaveBeenCalledWith(`/services/${TEST_SERVICE_ID}/clients`);
     });
 });

--- a/express/tests/services/lambda-facade/StubLambdaFacade.test.ts
+++ b/express/tests/services/lambda-facade/StubLambdaFacade.test.ts
@@ -1,7 +1,7 @@
 import LambdaFacade from "../../../src/services/lambda-facade/StubLambdaFacade";
 
 describe("Lambda Facade class tests", () => {
-    it("Exercise mock listClients method", async () => {
+    it("returns expected data from the listClients method", async () => {
         const mockLambdaFacade = new LambdaFacade();
 
         const expected = {
@@ -60,7 +60,21 @@ describe("Lambda Facade class tests", () => {
         expect(result).toEqual(expected);
     });
 
-    it("Exercise mock listServices method", async () => {
+    it("successfully adds landingPageUrl", async () => {
+        const mockLambdaFacade = new LambdaFacade();
+
+        // Initially landingPageUrl should not be present
+        let result = await mockLambdaFacade.listClients();
+        expect(result.data.Items).toBeDefined();
+        expect(result.data.Items?.[0]).not.toHaveProperty("landing_page_url");
+
+        await mockLambdaFacade.updateClient("", "", "", {landing_page_url: "https://example.com"});
+
+        result = await mockLambdaFacade.listClients();
+        expect(result.data.Items?.[0]).toHaveProperty("landing_page_url", {S: "https://example.com"});
+    });
+
+    it("returns expected data from the listServices method", async () => {
         const mockLambdaFacade = new LambdaFacade();
 
         const expected = {
@@ -80,7 +94,7 @@ describe("Lambda Facade class tests", () => {
         expect(result).toEqual(expected);
     });
 
-    it("Exercise mock updateClient method", async () => {
+    it("returns undefined from the updateClient method", async () => {
         const mockLambdaFacade = new LambdaFacade();
 
         const update: Record<string, string | string[]> = {};

--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -159,6 +159,12 @@ Conditions:
       ],
     ]
 
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - W8003
+
 Resources:
 
   #--- Fargate / ECS ---#

--- a/ui-automation-tests/acceptance-features/clients/change-identity-verification.feature
+++ b/ui-automation-tests/acceptance-features/clients/change-identity-verification.feature
@@ -43,7 +43,7 @@ Rule: The user can enable and then disable identity verification
         Then they should be redirected to a page with the title "Client details - GOV.UK One Login"
         And they should see the exact value "Yes" in the identity verification enabled field
         And they should see the exact value "Not added yet" in the claims field
-        And they should see the text "You have changed your identity verification"
+        And they should see the text "You have enabled identity verification. It is strongly recommended that you set a landing page URI."
         Then they click on the link that points to "/enter-identity-verification"
         And they should be redirected to a page with the title "Enter Identity Verification - GOV.UK One Login"
         When they select the "No" radio button

--- a/ui-automation-tests/acceptance-features/clients/change-landing-page-uri.feature
+++ b/ui-automation-tests/acceptance-features/clients/change-landing-page-uri.feature
@@ -1,0 +1,41 @@
+Feature: Users can change their Landing page URI
+  Background:
+    Given the user is signed in
+    And they goto on the test service page
+
+  Rule: The user tries to change their Landing page URI
+    Background:
+      When they click on the link that points to "/change-landing-page-url"
+      Then they should be redirected to a page with the title "Enter landing page URI - GOV.UK One Login"
+
+    @ci @smoke
+    Scenario Outline: user enters invalid URI as: <uri>
+      When they submit the landing page url "<uri>"
+      Then the error message "<errorMsg>" must be displayed for the landing page url field
+      Examples:
+        | uri               | errorMsg                                          |
+        |                   | Enter a URI                                      |
+        | someVerywrongURI  | Enter your URIs in the format https://example.com |
+
+    @ci @smoke
+    Scenario: The user clicks "Cancel" on the Enter landing page URI
+      When they click on the "Cancel" link
+      Then they should be redirected to a page with the title "Client details - GOV.UK One Login"
+      And they should see the exact value "Not added yet" in the landing page url field
+
+    @ci @smoke
+    Scenario: The user clicks "Back" on the Enter landing page URI
+      When they click on the "Back" link
+      Then they should be redirected to a page with the title "Client details - GOV.UK One Login"
+      And they should see the exact value "Not added yet" in the landing page url field
+
+  Rule: The user to update landing page URI
+    @ci @smoke
+    Scenario: The user successfully updates Landing page URI
+      Given they should see the exact value "Not added yet" in the landing page url field
+      When they click on the link that points to "/change-landing-page-url"
+      Then they should be redirected to a page with the title "Enter landing page URI - GOV.UK One Login"
+      When they submit the landing page url "https://landing-page.co.uk"
+      Then they should be redirected to a page with the title "Client details - GOV.UK One Login"
+      And they should see the exact value "https://landing-page.co.uk" in the landing page url field
+      And they should see the text "You have changed your Landing page URI"

--- a/ui-automation-tests/support/steps/clients-steps.ts
+++ b/ui-automation-tests/support/steps/clients-steps.ts
@@ -18,7 +18,8 @@ const fields = {
     "identity verification enabled": "idVerificationEnabledUri",
     claims: "claimsUri",
     "id token signing algorithm": "idTokenSigningAlgorithm",
-    "PKCE enforced": "changePKCEEnforcedUri"
+    "PKCE enforced": "changePKCEEnforcedUri",
+    "landing page url": "landingPageUrl"
 };
 
 Then("they should see the value for the Client ID {string}", async function (this: TestContext, text) {

--- a/ui-automation-tests/support/steps/input-steps.ts
+++ b/ui-automation-tests/support/steps/input-steps.ts
@@ -21,7 +21,8 @@ const fields = {
     "change your static key": "serviceUserPublicKey",
     "change your jwks url": "jwksUrl",
     "back channel logout uri": "backChannelLogoutUri",
-    "sector identifier uri": "sectorIdentifierUri"
+    "sector identifier uri": "sectorIdentifierUri",
+    "landing page url": "landingPageUrl"
 };
 
 When("they submit the {} {string}", async function (fieldName, value) {


### PR DESCRIPTION
### Wider context of change

RPs should have a landing page url registered if they are going to use identity verification. The ability to add landing page url to client config is being [added to authentication api](https://github.com/govuk-one-login/authentication-api/pull/6715)

### What’s changed

- add landingPageUrl to the 'Manage client' settings on Manage service page, with a corresponding page for updating landingPageUrl
- add hint text to the enable identity verification page to explain the need for landing page url
- conditionally add reminder about landing page url to the success banner when identity verification enabled
- generate success banner text in the controller to avoid complex logic in the template

NB: `landingPageUrl` is the term used in the Client Registry so this term is used in the SSE code. However, in the UI other urls are referred as URI (e.g. Sector identifier URI) so to be consistent with these other settings labels, the label 'Landing Page URI' is displayed in the UI.

### Manual testing

Deployed to dev alongside [changes to authentication-api](https://github.com/govuk-one-login/authentication-api/pull/6715) and observed the following successful test cases:

**1. Create a new service, which by default has no landingPageUrl set**
<img width="400" alt="Screenshot 2025-06-26 at 14 53 20" src="https://github.com/user-attachments/assets/c0b2a874-7720-4f23-bc7e-4dabbae3f271" />

**2. Hint text on enable identity verification page**
<img width="400" alt="Screenshot 2025-06-26 at 14 53 44" src="https://github.com/user-attachments/assets/99eea6e9-9549-43c9-970b-c3e044390ca3" />

**3. Success banner for enabling identity verification changes when no landingPageUrl set**
<img width="400" alt="Screenshot 2025-06-26 at 14 54 09" src="https://github.com/user-attachments/assets/e52ce2dd-d535-4659-86f0-7cd3bd1a2c95" />

**4. Success banner for enabling identity verification changes when landingPageUrl already set**
<img width="400" alt="Screenshot 2025-06-26 at 14 54 34" src="https://github.com/user-attachments/assets/4086f0aa-5b85-4cc9-82a5-88a6435d9710" />

**5. Success banner for disabling identity verification changes**
<img width="400" alt="Screenshot 2025-06-26 at 14 53 57" src="https://github.com/user-attachments/assets/a61f735e-2420-4af6-af95-0c719874a600" />

**6. Success banner for adding/changing landingPageUrl**
<img width="400" alt="Screenshot 2025-06-26 at 14 54 22" src="https://github.com/user-attachments/assets/5dc88178-cdb8-4de0-8069-4aa275cd4bee" />

**7. Invalid landingPageUrl entered**
<img width="400" alt="Screenshot 2025-06-26 at 14 54 47" src="https://github.com/user-attachments/assets/fc2827a4-c970-4a9e-9aa8-189c728f88e1" />

- also checked that adding/updating landingPageUrl was reflected in the client registry dynamo db table.

### Related PRs

- [changes to authentication-api](https://github.com/govuk-one-login/authentication-api/pull/6715) to accept landingPageUrl in client registration and updates