### PR TITLE
ATO-1861: Bump axios and remove redundant override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@aws-sdk/client-dynamodb": "^3.810.0",
         "@aws-sdk/client-sqs": "^3.810.0",
         "@pact-foundation/pact": "^13.1.5",
-        "axios": "^1.9.0",
+        "axios": "^1.11.0",
         "googleapis": "^148.0.0",
         "googleapis-common": "^7.2.0",
         "helmet": "^7.0.0"
@@ -6609,13 +6609,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@aws-sdk/client-dynamodb": "^3.810.0",
     "@aws-sdk/client-sqs": "^3.810.0",
     "@pact-foundation/pact": "^13.1.5",
-    "axios": "^1.9.0",
+    "axios": "^1.11.0",
     "googleapis": "^148.0.0",
     "googleapis-common": "^7.2.0",
     "helmet": "^7.0.0"
@@ -52,8 +52,5 @@
     "ts-jest": "^29.3.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.8.3"
-  },
-  "overrides": {
-    "form-data": "~4.0.4"
   }
 }


### PR DESCRIPTION
Context: `axios` depends on `form-data` which had a critical vulnerability, so the version of 'form-data' was [overridden](https://github.com/govuk-one-login/onboarding-self-service-experience/pull/1097) while waiting for axios to be updated. Now axios has been updated to use the patched version of `form-data' (4.0.4).
- update `axios` to the patched version and remove the redundant override relating to `form-data`.