### PR TITLE
ATO-1998: add back button links to enter-text-code pages

### DIFF
--- a/express/src/controllers/account.ts
+++ b/express/src/controllers/account.ts
@@ -112,7 +112,8 @@ export const showVerifyMobileWithSmsCode: RequestHandler = (req, res) => {
         headerActiveItem: "your-account",
         values: {
             mobileNumber: req.session.enteredMobileNumber,
-            textMessageNotReceivedUrl: "/account/change-phone-number/resend-text-code"
+            textMessageNotReceivedUrl: "/account/change-phone-number/resend-text-code",
+            backLinkPath: "/account/change-phone-number"
         }
     });
 };
@@ -145,7 +146,8 @@ export const verifyMobileWithSmsCode: RequestHandler = async (req, res) => {
                 values: {
                     securityCode: req.body.securityCode,
                     mobileNumber: req.session.enteredMobileNumber,
-                    textMessageNotReceivedUrl: "/account/change-phone-number/resend-text-code"
+                    textMessageNotReceivedUrl: "/account/change-phone-number/resend-text-code",
+                    backLinkPath: "/account/change-phone-number"
                 },
                 errorMessages: {
                     securityCode: "The code you entered is not correct or has expired - enter it again or request a new code"

--- a/express/src/controllers/register.ts
+++ b/express/src/controllers/register.ts
@@ -245,7 +245,8 @@ export const showSubmitMobileVerificationCode: RequestHandler = (req, res) => {
     res.render("common/enter-text-code.njk", {
         values: {
             mobileNumber: req.session.enteredMobileNumber,
-            textMessageNotReceivedUrl: RegisterRoutes.resendTextCode
+            textMessageNotReceivedUrl: RegisterRoutes.resendTextCode,
+            backLinkPath: RegisterRoutes.enterPhoneNumber
         }
     });
 };
@@ -259,7 +260,8 @@ export const submitMobileVerificationCode: RequestHandler = async (req, res) => 
         return res.render("common/enter-text-code.njk", {
             values: {
                 mobileNumber: req.session.mobileNumber,
-                textMessageNotReceivedUrl: RegisterRoutes.resendTextCode
+                textMessageNotReceivedUrl: RegisterRoutes.resendTextCode,
+                backLinkPath: RegisterRoutes.enterPhoneNumber
             }
         });
     }
@@ -289,7 +291,8 @@ export const submitMobileVerificationCode: RequestHandler = async (req, res) => 
                 values: {
                     securityCode: req.body.securityCode,
                     mobileNumber: req.session.enteredMobileNumber,
-                    textMessageNotReceivedUrl: RegisterRoutes.resendTextCode
+                    textMessageNotReceivedUrl: RegisterRoutes.resendTextCode,
+                    backLinkPath: RegisterRoutes.enterPhoneNumber
                 },
                 errorMessages: {
                     securityCode: "The code you entered is not correct or has expired - enter it again or request a new code"

--- a/express/src/views/common/enter-text-code.njk
+++ b/express/src/views/common/enter-text-code.njk
@@ -1,8 +1,11 @@
 {% extends "layouts/form.njk" %}
-{% from "macros/back-link.njk" import backLink %}
 
 {% set pageTitle = "Check your mobile phone" %}
-{% set backLinkHtml = backLink("#", {onclick: "history.back()"}) %}
+{% if values.backLinkPath !== undefined %}
+  {% set backLinkPath %}
+    {{ values.backLinkPath }}
+  {% endset %}
+{% endif %}
 
 {% block beforeForm %}
   <h1 class="govuk-heading-l">Check your mobile phone</h1>

--- a/express/tests/controllers/account.test.ts
+++ b/express/tests/controllers/account.test.ts
@@ -275,7 +275,8 @@ describe("showVerifyMobileWithSmsCode controller tests", () => {
             headerActiveItem: "your-account",
             values: {
                 mobileNumber: TEST_PHONE_NUMBER,
-                textMessageNotReceivedUrl: "/account/change-phone-number/resend-text-code"
+                textMessageNotReceivedUrl: "/account/change-phone-number/resend-text-code",
+                backLinkPath: "/account/change-phone-number"
             }
         });
     });
@@ -336,7 +337,8 @@ describe("verifyMobileWithSmsCode controller tests", () => {
             values: {
                 securityCode: TEST_SECURITY_CODE,
                 mobileNumber: TEST_PHONE_NUMBER,
-                textMessageNotReceivedUrl: "/account/change-phone-number/resend-text-code"
+                textMessageNotReceivedUrl: "/account/change-phone-number/resend-text-code",
+                backLinkPath: "/account/change-phone-number"
             },
             errorMessages: {
                 securityCode: "The code you entered is not correct or has expired - enter it again or request a new code"

--- a/express/tests/controllers/register.test.ts
+++ b/express/tests/controllers/register.test.ts
@@ -636,7 +636,8 @@ describe("showSubmitMobileVerificationCode controller tests", () => {
         expect(mockRes.render).toHaveBeenCalledWith("common/enter-text-code.njk", {
             values: {
                 mobileNumber: TEST_PHONE_NUMBER,
-                textMessageNotReceivedUrl: "/register/resend-text-code"
+                textMessageNotReceivedUrl: "/register/resend-text-code",
+                backLinkPath: "/register/enter-phone-number"
             }
         });
     });
@@ -666,7 +667,8 @@ describe("submitMobileVerificationCode controller tests", () => {
         expect(mockRes.render).toHaveBeenCalledWith("common/enter-text-code.njk", {
             values: {
                 mobileNumber: TEST_PHONE_NUMBER,
-                textMessageNotReceivedUrl: "/register/resend-text-code"
+                textMessageNotReceivedUrl: "/register/resend-text-code",
+                backLinkPath: "/register/enter-phone-number"
             }
         });
     });
@@ -713,7 +715,8 @@ describe("submitMobileVerificationCode controller tests", () => {
             values: {
                 securityCode: TEST_SECURITY_CODE,
                 mobileNumber: TEST_PHONE_NUMBER,
-                textMessageNotReceivedUrl: "/register/resend-text-code"
+                textMessageNotReceivedUrl: "/register/resend-text-code",
+                backLinkPath: "/register/enter-phone-number"
             },
             errorMessages: {
                 securityCode: "The code you entered is not correct or has expired - enter it again or request a new code"


### PR DESCRIPTION
# Onboarding Feature Deployment

> [!WARNING]
> Pull requests merged to `main` will be released to production, please ensure the checklist below is complete

Before any work can be merged to main in must meet the definition of done and be ready to deploy. While many of these tasks will be automated, the reviewers must take the responsibility of confirming the checklist below has been completed before this ticket can be merged.

## Checklist

-   [ ] this pull request meets the acceptance criteria of the ticket

-   [ ] this branch is up-to-date with the main branch

    `git fetch --all && git rebase origin/main`

-   [ ] these changes are backwards compatible (no breaking changes)

    -   all methods signatures and return values are the same
    -   any replaced methods are marked as `@deprecated`

-   [ ] tests have been written to cover any new or updated functionality

-   [ ] new configuration parameters have been deployed to all environments, see [configuration management](https://govukverify.atlassian.net/l/cp/N7q3Vh3r).

-   [ ] all external infrastructure dependencies have been updated in all environments

## Changes

[ _please list the changes this pull request is making_ ]

### `Added` for new features

### `Changed` for changes in existing functionality

Sign-in/enter-text-code does not have a back button anymore

### `Deprecated` for soon-to-be removed features

### `Removed` for now removed features

### `Fixed` for any bug fixes

Account and register /enter-text-code's back button works

### `Security` in case of vulnerabilities
